### PR TITLE
[FIX] OWImageNetEmbeddings: Preserve Data Indices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ Orange3_ImageAnalytics.egg-info
 build
 dist
 __pycache__
+.idea/
 

--- a/orangecontrib/imageanalytics/widgets/owimagenetembedding.py
+++ b/orangecontrib/imageanalytics/widgets/owimagenetembedding.py
@@ -185,9 +185,11 @@ class OWImageNetEmbedding(widget.OWWidget):
                         self.data.domain.class_vars,
                         self.data.domain.metas)
         embeddings = Table(domain, x, data.Y, data.metas)
+        embeddings.ids = self.data.ids[sel]
         self.send("Embeddings", embeddings)
         if np.any(np.logical_not(sel)):
             missing_data = Table(self.data[np.logical_not(sel)])
+            missing_data.ids = self.data.ids[np.logical_not(sel)]
             self.send("Missing Images", missing_data)
         else:
             self.send("Missing Images", None)


### PR DESCRIPTION
**Issue**
When passing data through ImageNetEmbeddings new indices are assigned to data instances. This prevents highlighting a subset of data in widgets like Geo Map since no indices overlap.

**Changes**
Copy indices of the input data to the output data.