### PR TITLE
[FIX] Image Import Fixes

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/owimageimport.py
@@ -377,9 +377,13 @@ class OWImportImages(widget.OWWidget):
         """
         existing = None
         for pathitem in self.recent_paths:
-            if os.path.samefile(pathitem.abspath, path):
-                existing = pathitem
-                break
+            try:
+                if os.path.samefile(pathitem.abspath, path):
+                    existing = pathitem
+                    break
+            except FileNotFoundError:
+                # file not found if the `pathitem.abspath` no longer exists
+                pass
 
         model = self.recent_cb.model()
 

--- a/orangecontrib/imageanalytics/widgets/owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/owimageimport.py
@@ -344,17 +344,31 @@ class OWImportImages(widget.OWWidget):
                 os.path.samefile(self.currentPath, path):
             return True
 
-        if not os.path.exists(path):
-            warnings.warn("'{}' does not exist".format(path), UserWarning)
-            return False
-        elif not os.path.isdir(path):
-            warnings.warn("'{}' is not a directory".format(path), UserWarning)
-            return False
+        success = True
+        error = None
+        if path is not None:
+            if not os.path.exists(path):
+                error = "'{}' does not exist".format(path)
+                path = None
+                success = False
+            elif not os.path.isdir(path):
+                error = "'{}' is not a directory".format(path)
+                path = None
+                success = False
 
-        newindex = self.addRecentPath(path)
-        self.recent_cb.setCurrentIndex(newindex)
-        if newindex >= 0:
-            self.currentPath = path
+        if error is not None:
+            self.error(error)
+            warnings.warn(error, UserWarning, stacklevel=3)
+        else:
+            self.error()
+
+        if path is not None:
+            newindex = self.addRecentPath(path)
+            self.recent_cb.setCurrentIndex(newindex)
+            if newindex >= 0:
+                self.currentPath = path
+            else:
+                self.currentPath = None
         else:
             self.currentPath = None
         self.__actions.reload.setEnabled(self.currentPath is not None)
@@ -362,7 +376,7 @@ class OWImportImages(widget.OWWidget):
         if self.__state == State.Processing:
             self.cancel()
 
-        return True
+        return success
 
     def addRecentPath(self, path):
         """

--- a/orangecontrib/imageanalytics/widgets/owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/owimageimport.py
@@ -622,10 +622,15 @@ class OWImportImages(widget.OWWidget):
 
             cat_data = numpy.array(cat_data, dtype=float)
             meta_data = numpy.array(meta_data, dtype=object)
-            table = Orange.data.Table.from_numpy(
-                domain, numpy.empty((len(cat_data), 0), dtype=float),
-                cat_data, meta_data
-            )
+
+            if len(meta_data):
+                table = Orange.data.Table.from_numpy(
+                    domain, numpy.empty((len(cat_data), 0), dtype=float),
+                    cat_data, meta_data
+                )
+            else:
+                # empty results, no images found
+                table = None
         else:
             table = None
 

--- a/orangecontrib/imageanalytics/widgets/tests/test_owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/tests/test_owimageimport.py
@@ -1,0 +1,58 @@
+import os
+import tempfile
+import unittest
+
+from AnyQt.QtCore import Qt
+from AnyQt.QtWidgets import QApplication
+from AnyQt.QtTest import QTest, QSignalSpy
+
+from orangecontrib.imageanalytics.widgets import owimageimport
+
+
+class TestOWImageImport(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        app = QApplication.instance()
+        if app is None:
+            app = QApplication([])
+        cls.app = app
+
+    @classmethod
+    def tearDownClass(cls):
+        QTest.qWait(40)
+        cls.app = None
+
+    def setUp(self):
+        self.widget = owimageimport.OWImportImages()
+
+    def tearDown(self):
+        self.widget.onDeleteWidget()
+        self.widget.deleteLater()
+        self.widget = None
+
+    def _startandwait(self, widget):
+        spy = QSignalSpy(widget.blockingStateChanged)
+        widget.start()
+        assert len(spy)
+        assert spy[-1] == [True]
+        assert spy.wait(5000)
+        assert spy[-1] == [False]
+        self.assertFalse(widget.isBlocking())
+
+    def test_empty_dir(self):
+        widget = self.widget
+        with tempfile.TemporaryDirectory() as tempdir:
+            widget.setCurrentPath(tempdir)
+            self._startandwait(widget)
+            widget.commit()
+
+    def test_invalid_imgs(self):
+        widget = self.widget
+        with tempfile.TemporaryDirectory() as tempdir:
+            # create an empty single invalid image
+            with open(os.path.join(tempdir, "img.png"), 'x'):
+                pass
+            widget.setCurrentPath(tempdir)
+            self._startandwait(widget)
+            widget.commit()


### PR DESCRIPTION
Changes:
* Handle an error when a directory in the 'Recent Paths' list is (re)moved after the widget is created
* Fix an array dimension error when the scanned images list contains only invalid results
