### PR TITLE
[FIX] Widget owimageimport opens in the parent directory

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/owimageimport.py
@@ -259,7 +259,7 @@ class OWImportImages(widget.OWWidget):
     def __runOpenDialog(self):
         startdir = os.path.expanduser("~/")
         if self.recent_paths:
-            startdir = self.recent_paths[0].abspath
+            startdir = os.path.dirname(self.recent_paths[0].abspath)
 
         if OWImportImages.Modality == Qt.WindowModal:
             dlg = QFileDialog(


### PR DESCRIPTION
Issue
Import Images reopens in the wrong directory (should open one above the one it opens now, not the last opened directory)