### PR TITLE
Image Embedding: handle StreamResetError

### DIFF
--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -210,12 +210,6 @@ class ImageEmbedder(Http2Client):
         image_bytes_io.seek(0)
         image_bytes = image_bytes_io.read()
         image_bytes_io.close()
-
-        # todo: temporary here because of a backend bug: when body
-        # of exactly 19456 bytes in size is sent in the http2 post
-        # request the request doesn't reach the upstream servers
-        if len(image_bytes) == 19456:
-            return None
         return image_bytes
 
     def _get_responses_from_server(self, http_streams, cache_keys,


### PR DESCRIPTION
Handle the case when a single stream is reset by the server (skip the image and continue instead of raising an error). Solves `hyper.http20.exceptions.StreamResetError: Stream forcefully closed` from https://github.com/biolab/orange3-imageanalytics/issues/20.