### PR TITLE
Http2 client: generalize connection errors handling

### DIFF
--- a/orangecontrib/imageanalytics/tests/test_image_embedder.py
+++ b/orangecontrib/imageanalytics/tests/test_image_embedder.py
@@ -97,6 +97,10 @@ class ImageEmbedderTest(unittest.TestCase):
         with self.assertRaises(ConnectionError):
             self.embedder(self.single_example)
 
+        ConnectionMock.side_effect = BrokenPipeError
+        with self.assertRaises(ConnectionError):
+            self.embedder(self.single_example)
+
     @patch.object(DummyHttp2Connection, 'get_response')
     def test_on_stream_reset_by_server(self, ConnectionMock):
         ConnectionMock.side_effect = StreamResetError


### PR DESCRIPTION
Instead of catching all possible connection errors and in some cases os errors, catch the base class of the error instead. Add handling of the connection error when disconnecting.