### PR TITLE
Add-on description is now in about.md

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,6 +1,9 @@
 Image Analytics
 ---------------
 
-Load images from folders and use pre-trained deep network embedding to represent them with a vector of features. 
-Then, use Orange's standard arsenal of widgets to cluster or classify the images, or perform any 
-kind of feature-based analysis. Use Image Viewer from core Orange to visualize the images.
+Simplifies loading of images and through deep network-based embedding 
+enables their analysis. Embedding represents images with feature vector,
+allowing the use of Orange's standard arsenal of widgets for 
+clustering, classification or any other kind of 
+feature-based analysis. Use Image Viewer from the core Orange 
+to visualize the images.

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ import os
 
 from setuptools import setup, find_packages
 
-with io.open('README.md', 'r', encoding='utf-8') as f:
-    README = f.read()
+with io.open('about.md', 'r', encoding='utf-8') as f:
+    ABOUT = f.read()
 
 NAME = 'Orange3-ImageAnalytics'
 
 MAJOR = 0
 MINOR = 1
-MICRO = 3
+MICRO = 4
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 AUTHOR = 'Bioinformatics Laboratory, FRI UL'
@@ -20,7 +20,7 @@ AUTHOR_EMAIL = 'contact@orange.biolab.si'
 
 URL = 'http://orange.biolab.si/download'
 DESCRIPTION = 'Orange3 add-on for image data mining.'
-LONG_DESCRIPTION = README
+LONG_DESCRIPTION = ABOUT
 LICENSE = 'GPL3+'
 
 CLASSIFIERS = [


### PR DESCRIPTION
Before the longer description of the add-on was coming from README.md. Longer description is displayed in the Add On window of Orange, and information on python-based installation does not fit there. Now the description is coming from about.md which contains only general information about the functionality of the add-on.