### PR TITLE
Http2Client: check for env vars when setting api url and port

### DIFF
--- a/orangecontrib/imageanalytics/http2_client.py
+++ b/orangecontrib/imageanalytics/http2_client.py
@@ -5,6 +5,7 @@ except ImportError:
     # json decoder in Python3.4 raises ValueError on invalid json
     JSONDecodeError = ValueError
 import logging
+from os import getenv
 from socket import gaierror, timeout
 
 from h2.exceptions import ProtocolError
@@ -25,8 +26,11 @@ class Http2Client(object):
     _no_conn_err = "No connection with server, call reconnect_to_server()"
 
     def __init__(self, server_url, server_port):
-        self._server_url = server_url
-        self._server_port = server_port
+        self._server_url = getenv('ORANGE_EMBEDDING_API_URL', server_url)
+        self._server_port = getenv('ORANGE_EMBEDDING_API_PORT', server_port)
+
+        if isinstance(self._server_port, str):
+            self._server_port = int(self._server_port)
 
         self._server_connection = self._connect_to_server()
         self._max_concurrent_streams = self._ack_max_concurrent_streams()
@@ -115,7 +119,7 @@ class Http2Client(object):
 
         except ProtocolError:
             error = MaxNumberOfRequestsError(
-                "Maximum number of http2 requests through a single"
+                "Maximum number of http2 requests through a single "
                 "connection exceeded")
             log.warning(error, exc_info=True)
             raise error

--- a/orangecontrib/imageanalytics/http2_client.py
+++ b/orangecontrib/imageanalytics/http2_client.py
@@ -25,13 +25,8 @@ class Http2Client(object):
     """Base class for an http2 client."""
     _no_conn_err = "No connection with server, call reconnect_to_server()"
 
-    def __init__(self, server_url, server_port):
+    def __init__(self, server_url):
         self._server_url = getenv('ORANGE_EMBEDDING_API_URL', server_url)
-        self._server_port = getenv('ORANGE_EMBEDDING_API_PORT', server_port)
-
-        if isinstance(self._server_port, str):
-            self._server_port = int(self._server_port)
-
         self._server_connection = self._connect_to_server()
         self._max_concurrent_streams = self._ack_max_concurrent_streams()
 
@@ -52,11 +47,7 @@ class Http2Client(object):
         self._max_concurrent_streams = None
 
     def _connect_to_server(self):
-        return HTTP20Connection(
-            host=self._server_url,
-            port=self._server_port,
-            force_proto='h2'
-        )
+        return HTTP20Connection(host=self._server_url, force_proto='h2')
 
     def _ack_max_concurrent_streams(self):
         if not self._server_ping_successful():

--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -37,9 +37,8 @@ class ImageEmbedder(Http2Client):
     """
     _cache_file_blueprint = '{:s}_{:s}_embeddings.pickle'
 
-    def __init__(self, model, layer,
-                 server_url='api.biolab.si', server_port=8080):
-        super().__init__(server_url, server_port)
+    def __init__(self, model, layer, server_url='api.biolab.si:8080'):
+        super().__init__(server_url)
         model_settings = self._get_model_settings_confidently(model, layer)
 
         self._model = model

--- a/orangecontrib/imageanalytics/tests/test_image_embedder.py
+++ b/orangecontrib/imageanalytics/tests/test_image_embedder.py
@@ -70,7 +70,6 @@ class ImageEmbedderTest(unittest.TestCase):
             model='inception-v3',
             layer='penultimate',
             server_url='example.com',
-            server_port=80
         )
         self.embedder.clear_cache()
         self.single_example = [_EXAMPLE_IMAGE_JPG]
@@ -164,7 +163,6 @@ class ImageEmbedderTest(unittest.TestCase):
             model='inception-v3',
             layer='penultimate',
             server_url='example.com',
-            server_port=80
         )
         self.assertEqual(len(self.embedder._cache_dict), 1)
 
@@ -173,7 +171,6 @@ class ImageEmbedderTest(unittest.TestCase):
             model='inception-v3',
             layer='penultimate',
             server_url='example.com',
-            server_port=80
         )
         self.assertEqual(len(self.embedder._cache_dict), 0)
 
@@ -187,7 +184,6 @@ class ImageEmbedderTest(unittest.TestCase):
             model='inception-v3',
             layer='penultimate',
             server_url='example.com',
-            server_port=80
         )
         self.assertEqual(len(self.embedder._cache_dict), 1)
 
@@ -217,7 +213,6 @@ class ImageEmbedderTest(unittest.TestCase):
                 model='invalid_model',
                 layer='penultimate',
                 server_url='example.com',
-                server_port=80
             )
 
     @patch(_TESTED_MODULE.format('HTTP20Connection'), DummyHttp2Connection)
@@ -227,7 +222,6 @@ class ImageEmbedderTest(unittest.TestCase):
                 model='inception-v3',
                 layer='first',
                 server_url='example.com',
-                server_port=80
             )
 
     @patch(_TESTED_MODULE.format('HTTP20Connection'), DummyHttp2Connection)
@@ -243,24 +237,15 @@ class ImageEmbedderTest(unittest.TestCase):
         self.assertEqual(len(self.embedder._cache_dict), 1)
 
     @patch(_TESTED_MODULE.format('HTTP20Connection'), DummyHttp2Connection)
-    def test_server_url_port_env_vars(self):
-        url_value = 'url'
-        port_value = '1234'
-
+    def test_server_url_env_var(self):
+        url_value = 'url:1234'
         self.assertTrue(self.embedder._server_url != url_value)
-        self.assertTrue(self.embedder._server_port != int(port_value))
 
         environ['ORANGE_EMBEDDING_API_URL'] = url_value
-        environ['ORANGE_EMBEDDING_API_PORT'] = port_value
         self.embedder = ImageEmbedder(
             model='inception-v3',
             layer='penultimate',
             server_url='example.com',
-            server_port=80
         )
-
         self.assertTrue(self.embedder._server_url == url_value)
-        self.assertTrue(self.embedder._server_port == int(port_value))
-
         del environ['ORANGE_EMBEDDING_API_URL']
-        del environ['ORANGE_EMBEDDING_API_PORT']


### PR DESCRIPTION
Fixes https://github.com/biolab/orange3-imageanalytics/issues/29.