### PR TITLE
[ENH] Add drag/drop support to "Import Images" widget

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/owimageimport.py
@@ -641,6 +641,7 @@ class OWImportImages(widget.OWWidget):
     def onDeleteWidget(self):
         self.cancel()
         self.__executor.shutdown(wait=True)
+        self.__invalidated = False
 
     def eventFilter(self, receiver, event):
         # re-implemented from QWidget

--- a/orangecontrib/imageanalytics/widgets/owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/owimageimport.py
@@ -24,15 +24,15 @@ from types import SimpleNamespace as namespace
 
 import numpy
 
-from AnyQt.QtGui import (
-    QAction, QPushButton, QComboBox, QLabel, QApplication, QStyle,
-    QImageReader, QFileDialog, QFileIconProvider, QStandardItem,
-    QStackedWidget, QProgressBar, QWidget, QHBoxLayout, QVBoxLayout,
-    QLabel
-)
+from AnyQt.QtCore import Qt, QEvent, QFileInfo, QThread
+from AnyQt.QtCore import pyqtSlot as Slot
+from AnyQt.QtGui import QStandardItem, QImageReader, QDropEvent
 
-from PyQt4.QtCore import Qt, QEvent, QFileInfo, QThread
-from PyQt4.QtCore import pyqtSlot as Slot
+from AnyQt.QtWidgets import (
+    QAction, QPushButton, QComboBox, QApplication, QStyle, QFileDialog,
+    QFileIconProvider, QStackedWidget, QProgressBar, QWidget, QHBoxLayout,
+    QVBoxLayout, QLabel
+)
 
 import Orange.data
 


### PR DESCRIPTION
Source directory can be specified by drag/drop onto the 'Recent' combo box.

