### PR TITLE
Image Embedding: minor bug fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false   # use container-based infrastructure
 python:
   - "3.4"
   - "3.5"
-  - "3.6"
 
 addons:
     apt:

--- a/orangecontrib/imageanalytics/widgets/owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/owimageembedding.py
@@ -91,7 +91,7 @@ class OWImageEmbedding(OWWidget):
             return
 
         self._image_attributes = self._filter_image_attributes(data)
-        if not self._image_attributes:
+        if self._image_attributes is None:
             input_data_info_text = (
                 "Data with {:d} instances, but without image attributes."
                 .format(len(data)))
@@ -121,7 +121,11 @@ class OWImageEmbedding(OWWidget):
         self.commit()
 
     def commit(self):
-        if not self._image_attributes or not self._input_data:
+        if self._image_embedder is None:
+            self._set_server_info(connected=False)
+            return
+
+        if self._image_attributes is None or self._input_data is None:
             self.send(_Output.EMBEDDINGS, None)
             self.send(_Output.SKIPPED_IMAGES, None)
             return

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 hyper==0.7.0
-numpy
+numpy>=1.10.0
 Orange3>=3.3.5
 Pillow>=2.7.0


### PR DESCRIPTION
Fix for https://github.com/biolab/orange3-imageanalytics/issues/33. Also fixes cache file loading and prevents image embedding before a connection is fully established. Temporarily remove failing python 3.6 build on travis.