### PR TITLE
[FIX] Add type=origin to image file attribute

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/owimageembedding.py
@@ -1,6 +1,5 @@
 import logging
 import traceback
-import os.path
 from types import SimpleNamespace as namespace
 
 import numpy as np
@@ -207,7 +206,8 @@ class OWImageEmbedding(OWWidget):
 
         file_paths_mask = file_paths == file_paths_attr.Unknown
         file_paths_valid = file_paths[~file_paths_mask]
-        file_paths_valid = os.path.join(origin, file_paths_valid)
+        if origin:
+            file_paths_valid = origin + "/" + file_paths_valid
 
         ticks = iter(np.linspace(0.0, 100.0, file_paths_valid.size))
         set_progress = qconcurrent.methodinvoke(

--- a/orangecontrib/imageanalytics/widgets/owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/owimageembedding.py
@@ -1,5 +1,6 @@
 import logging
 import traceback
+import os.path
 from types import SimpleNamespace as namespace
 
 import numpy as np
@@ -206,7 +207,7 @@ class OWImageEmbedding(OWWidget):
 
         file_paths_mask = file_paths == file_paths_attr.Unknown
         file_paths_valid = file_paths[~file_paths_mask]
-        file_paths_valid = origin + "/" + file_paths_valid
+        file_paths_valid = os.path.join(origin, file_paths_valid)
 
         ticks = iter(np.linspace(0.0, 100.0, file_paths_valid.size))
         set_progress = qconcurrent.methodinvoke(

--- a/orangecontrib/imageanalytics/widgets/owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/owimageembedding.py
@@ -1,4 +1,5 @@
 import logging
+import os.path
 import traceback
 from types import SimpleNamespace as namespace
 
@@ -206,8 +207,7 @@ class OWImageEmbedding(OWWidget):
 
         file_paths_mask = file_paths == file_paths_attr.Unknown
         file_paths_valid = file_paths[~file_paths_mask]
-        if origin:
-            file_paths_valid = origin + "/" + file_paths_valid
+        file_paths_valid = np.vectorize(os.path.join)(origin, file_paths_valid)
 
         ticks = iter(np.linspace(0.0, 100.0, file_paths_valid.size))
         set_progress = qconcurrent.methodinvoke(

--- a/orangecontrib/imageanalytics/widgets/owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/owimageembedding.py
@@ -199,11 +199,14 @@ class OWImageEmbedding(OWWidget):
 
         file_paths_attr = self._image_attributes[self.cb_image_attr_current_id]
         file_paths = self._input_data[:, file_paths_attr].metas.flatten()
+        origin = file_paths_attr.attributes.get("origin", "")
+
         assert file_paths_attr.is_string
         assert file_paths.dtype == np.dtype('O')
 
         file_paths_mask = file_paths == file_paths_attr.Unknown
         file_paths_valid = file_paths[~file_paths_mask]
+        file_paths_valid = origin + "/" + file_paths_valid
 
         ticks = iter(np.linspace(0.0, 100.0, file_paths_valid.size))
         set_progress = qconcurrent.methodinvoke(


### PR DESCRIPTION
##### Issue

When importing images, the image attribute (the one with the type=image) should also store the origin of the images, that is, the root directory where the images are located. The image file names in the table are then relative paths from that origin. Current image loader did not use the origin and instead used the absolute path for image file names.

##### Description of changes

Image loader now adds origin information to image attribute. It also truncates the names of the image file such that these are relative paths from the origin.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation