### PR TITLE
Orange ImageAnalytics client updated to repeat sending images when request not successful

### DIFF
--- a/orangecontrib/imageanalytics/http2_client.py
+++ b/orangecontrib/imageanalytics/http2_client.py
@@ -13,7 +13,14 @@ from h2.exceptions import ProtocolError
 from hyper import HTTP20Connection
 from hyper.http20.exceptions import StreamResetError
 
+import hyper.http20.stream
+from .hyper import stream as local_stream
+
 log = logging.getLogger(__name__)
+
+if hyper.__version__ < '0.7.1':  # TODO: remove when version > 0.7.0
+    hyper.http20.stream.Stream.send_data = local_stream.Stream.send_data
+    hyper.http20.stream.Stream._send_chunk = local_stream.Stream._send_chunk
 
 
 class MaxNumberOfRequestsError(Exception):

--- a/orangecontrib/imageanalytics/hyper/stream.py
+++ b/orangecontrib/imageanalytics/hyper/stream.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""
+Temporary fix for hyper library until next version from 0.7.0 is out
+"""
+import logging
+
+log = logging.getLogger(__name__)
+
+# Define the largest chunk of data we'll send in one go. Realistically, we
+# should take the MSS into account but that's pretty dull, so let's just say
+# 1kB and call it a day.
+MAX_CHUNK = 1024
+
+
+class Stream(object):
+
+    def send_data(self, data, final):
+        """
+        Send some data on the stream. If this is the end of the data to be
+        sent, the ``final`` flag _must_ be set to True. If no data is to be
+        sent, set ``data`` to ``None``.
+        """
+        # Define a utility iterator for file objects.
+        def file_iterator(fobj):
+            while True:
+                data = fobj.read(MAX_CHUNK)
+                yield data
+                if len(data) < MAX_CHUNK:
+                    break
+
+        # Build the appropriate iterator for the data, in chunks of CHUNK_SIZE.
+        if hasattr(data, 'read'):
+            chunks = file_iterator(data)
+        else:
+            chunks = (data[i:i+MAX_CHUNK]
+                      for i in range(0, len(data), MAX_CHUNK))
+
+        # since we need to know when we have a last package we need to know
+        # if there is another package in advance
+        cur_chunk = next(chunks)
+        while True:
+            try:
+                next_chunk = next(chunks)
+                self._send_chunk(cur_chunk, False)
+            except StopIteration:
+                self._send_chunk(cur_chunk, final)
+                break
+            cur_chunk = next_chunk
+
+
+    def _send_chunk(self, data, final):
+        """
+        Implements most of the sending logic.
+        Takes a single chunk of size at most MAX_CHUNK, wraps it in a frame and
+        sends it. Optionally sets the END_STREAM flag if this is the last chunk
+        (determined by being of size less than MAX_CHUNK) and no more data is
+        to be sent.
+        """
+        # If we don't fit in the connection window, try popping frames off the
+        # connection in hope that one might be a window update frame.
+        while len(data) > self._out_flow_control_window:
+            self._recv_cb()
+
+        # Send the frame and decrement the flow control window.
+        with self._conn as conn:
+            conn.send_data(
+                stream_id=self.stream_id, data=data, end_stream=final
+            )
+        self._send_outstanding_data()
+
+        if final:
+            self.local_closed = True

--- a/orangecontrib/imageanalytics/hyper/stream.py
+++ b/orangecontrib/imageanalytics/hyper/stream.py
@@ -37,15 +37,16 @@ class Stream(object):
 
         # since we need to know when we have a last package we need to know
         # if there is another package in advance
-        cur_chunk = next(chunks)
-        while True:
-            try:
+        cur_chunk = None
+        try:
+            cur_chunk = next(chunks)
+            while True:
                 next_chunk = next(chunks)
                 self._send_chunk(cur_chunk, False)
-            except StopIteration:
+                cur_chunk = next_chunk
+        except StopIteration:
+            if cur_chunk is not None:  # cur_chunk none when no chunks to send
                 self._send_chunk(cur_chunk, final)
-                break
-            cur_chunk = next_chunk
 
 
     def _send_chunk(self, data, final):

--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -330,7 +330,7 @@ class ImageEmbedder(Http2Client):
                 embeddings.append(self.CANNOT_LOAD)
 
                 if image_processed_callback:
-                    image_processed_callback()
+                    image_processed_callback(success=False)
                 continue
 
 
@@ -341,7 +341,7 @@ class ImageEmbedder(Http2Client):
                 embeddings.append(embedding)
 
                 if image_processed_callback:
-                    image_processed_callback()
+                    image_processed_callback(success=embedding is not None)
                 continue
 
             try:
@@ -361,7 +361,7 @@ class ImageEmbedder(Http2Client):
                 self._cache_dict[cache_key] = embedding
 
             if image_processed_callback:
-                image_processed_callback()
+                image_processed_callback(embeddings[-1] is not None)
 
         return embeddings
 

--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -88,7 +88,7 @@ class ImageEmbedder(Http2Client):
     CANNOT_LOAD = "cannot load"
 
     def __init__(self, model="inception-v3", layer="penultimate",
-                 server_url='api.biolab.si:8080'):
+                 server_url='api.garaza.io:443'):
         super().__init__(server_url)
         model_settings = self._get_model_settings_confidently(model, layer)
         self._model = model

--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -29,32 +29,37 @@ MODELS = {
         'name': 'Inception v3',
         'description': 'Google\'s Inception v3 model trained on ImageNet.',
         'target_image_size': (299, 299),
-        'layers': ['penultimate']
+        'layers': ['penultimate'],
+        'order': 0
     },
     'painters': {
         'name': 'Painters',
         'description':
             'A model trained to predict painters from artwork images.',
         'target_image_size': (256, 256),
-        'layers': ['penultimate']
+        'layers': ['penultimate'],
+        'order': 3
     },
     'deeploc': {
         'name': 'DeepLoc',
         'description': 'A model trained to analyze yeast cell images.',
         'target_image_size': (64, 64),
-        'layers': ['penultimate']
+        'layers': ['penultimate'],
+        'order': 4
     },
     'vgg16': {
         'name': 'VGG-16',
         'description': '16-layer image recognition model trained on ImageNet.',
         'target_image_size': (224, 224),
-        'layers': ['penultimate']
+        'layers': ['penultimate'],
+        'order': 1
     },
     'vgg19': {
         'name': 'VGG-19',
         'description': '19-layer image recognition model trained on ImageNet.',
         'target_image_size': (224, 224),
-        'layers': ['penultimate']
+        'layers': ['penultimate'],
+        'order': 2
     }
 }
 

--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -66,7 +66,7 @@ class ImageEmbedder(Http2Client):
     >>> embedded_images, skipped_images, num_skipped = image_embedder(images)
     """
     _cache_file_blueprint = '{:s}_{:s}_embeddings.pickle'
-    maximal_trials = 10
+    MAX_REPEATS = 4
     CANNOT_LOAD = "cannot load"
 
     def __init__(self, model="inception-v3", layer="penultimate",
@@ -166,12 +166,12 @@ class ImageEmbedder(Http2Client):
             self.reconnect_to_server()
 
         all_embeddings = [None] * len(file_paths)
-        trials_counter = 0
+        repeats_counter = 0
 
         # repeat while all images has embeddings or
         # while counter counts out (prevents cycling)
         while len([el for el in all_embeddings if el is None]) > 0 and \
-            trials_counter < self.maximal_trials:
+            repeats_counter < self.MAX_REPEATS:
 
             # take all images without embeddings yet
             selected_indices = [i for i, v in enumerate(all_embeddings)
@@ -198,7 +198,7 @@ class ImageEmbedder(Http2Client):
                     all_embeddings[i] = emb
 
                 self.persist_cache()
-            trials_counter += 1
+            repeats_counter += 1
 
         # change images that were not loaded from 'cannot loaded' to None
         all_embeddings = \

--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -37,6 +37,24 @@ MODELS = {
             'A model trained to predict painters from artwork images.',
         'target_image_size': (256, 256),
         'layers': ['penultimate']
+    },
+    'deeploc': {
+        'name': 'DeepLoc',
+        'description': 'A model trained to analyze yeast cell images.',
+        'target_image_size': (64, 64),
+        'layers': ['penultimate']
+    },
+    'vgg16': {
+        'name': 'VGG-16',
+        'description': '16-layer image recognition model trained on ImageNet.',
+        'target_image_size': (224, 224),
+        'layers': ['penultimate']
+    },
+    'vgg19': {
+        'name': 'VGG-19',
+        'description': '19-layer image recognition model trained on ImageNet.',
+        'target_image_size': (224, 224),
+        'layers': ['penultimate']
     }
 }
 

--- a/orangecontrib/imageanalytics/tests/test_image_embedder.py
+++ b/orangecontrib/imageanalytics/tests/test_image_embedder.py
@@ -285,3 +285,12 @@ class ImageEmbedderTest(unittest.TestCase):
         self.embedder.cancelled = True
         with self.assertRaises(Exception):
             self.embedder(self.single_example)
+
+    def test_version(self):
+        """
+        Test if new version of a hyper library is published
+        When this test start to fails remove temporary fix in http2_client
+        marked with TODO
+        """
+        import hyper
+        self.assertEqual(hyper.__version__, "0.7.0")

--- a/orangecontrib/imageanalytics/widgets/owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/owimageembedding.py
@@ -119,7 +119,7 @@ class OWImageEmbedding(OWWidget):
         self.cancel_button.clicked.connect(self.cancel)
         hbox = hBox(self.controlArea)
         hbox.layout().addWidget(self.cancel_button)
-        self.cancel_button.hide()
+        self.cancel_button.setDisabled(True)
 
     def _init_server_connection(self):
         self.setBlocking(False)
@@ -193,7 +193,7 @@ class OWImageEmbedding(OWWidget):
             return
 
         self._set_server_info(connected=True)
-        self.cancel_button.show()
+        self.cancel_button.setDisabled(False)
         self.cb_image_attr.setDisabled(True)
         self.cb_embedder.setDisabled(True)
 
@@ -266,7 +266,7 @@ class OWImageEmbedding(OWWidget):
 
         task, self._task = self._task, None
         self.auto_commit_widget.setDisabled(False)
-        self.cancel_button.hide()
+        self.cancel_button.setDisabled(True)
         self.cb_image_attr.setDisabled(False)
         self.cb_embedder.setDisabled(False)
         self.progressBarFinished(processEvents=None)
@@ -334,7 +334,7 @@ class OWImageEmbedding(OWWidget):
                 pass
 
             self.auto_commit_widget.setDisabled(False)
-            self.cancel_button.hide()
+            self.cancel_button.setDisabled(True)
             self.progressBarFinished(processEvents=None)
             self.setBlocking(False)
             self.cb_image_attr.setDisabled(False)

--- a/orangecontrib/imageanalytics/widgets/owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/owimageembedding.py
@@ -211,8 +211,9 @@ class OWImageEmbedding(OWWidget):
         set_progress = qconcurrent.methodinvoke(
             self, "__progress_set", (float,))
 
-        def advance():
-            set_progress(next(ticks))
+        def advance(success=True):
+            if success:
+                set_progress(next(ticks))
 
         def cancel():
             task.future.cancel()

--- a/orangecontrib/imageanalytics/widgets/owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/owimageembedding.py
@@ -52,7 +52,8 @@ class OWImageEmbedding(OWWidget):
 
     def __init__(self):
         super().__init__()
-        self.embedders = sorted(list(EMBEDDERS_INFO))
+        self.embedders = sorted(list(EMBEDDERS_INFO),
+                                key=lambda k: EMBEDDERS_INFO[k]['order'])
         self._image_attributes = None
         self._input_data = None
         self._log = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hyper==0.7.0
+hyper>=0.7.0
 numpy>=1.10.0
 Orange3>=3.3.5
 Pillow>=2.7.0


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Image Embedding client is sometimes rejected by a server due to too many requests and some other reasons, what means that that it does not retrieve embeddings for some images.

##### Description of changes

The client was changed that way that images which are rejected are sent to the a again until the client gets their embeddings or a maximum number of attempts is reached. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation