### PR TITLE
[FIX] Import Images Script: do not crash if importing is cancelled

### DIFF
--- a/orangecontrib/imageanalytics/import_images.py
+++ b/orangecontrib/imageanalytics/import_images.py
@@ -63,7 +63,7 @@ class ImportImages:
         patterns = ["*.{}".format(fmt.lower() if self.case_insensitive else fmt)
                     for fmt in self.formats]
 
-        images = self.image_meta(scan(start_dir), patterns)
+        images = self.image_meta(scan(start_dir), patterns) or []
         categories = {}
         for imeta in images:
             # derive categories from the path relative to the starting dir

--- a/orangecontrib/imageanalytics/tests/test_import_images.py
+++ b/orangecontrib/imageanalytics/tests/test_import_images.py
@@ -1,0 +1,22 @@
+import logging
+import unittest
+
+from orangecontrib.imageanalytics.import_images import ImportImages
+
+class ImportImagesTest(unittest.TestCase):
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+        self.import_images = ImportImages()
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
+    def test_import_cancelled(self):
+        """
+        Script or widget should not crash if importing is cancelled and result is None
+        which cannot be iterable.
+        GH-68
+        """
+        import_images = self.import_images
+        import_images.cancelled = True
+        import_images("/")


### PR DESCRIPTION
##### Issue
Import Images script or widget is crashed if it is cancelled.

##### Description of changes
If cancelled and returned `None` set to `[]`.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation