### PR TITLE
[FIX] Import Images: set 0 images and categories when no data

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/owimageimport.py
@@ -550,6 +550,8 @@ class OWImportImages(widget.OWWidget):
             self._n_image_data = len(data)
             self._n_image_categories = len(data.domain.class_var.values)\
                 if data.domain.class_var else 0
+        else:
+            self._n_image_data, self._n_image_categories = 0, 0
 
         self.data = data
         self._n_skipped = n_skipped


### PR DESCRIPTION
##### Issue
Firstly we import a folder with images and then there is shown how many images were imported, skipped, etc.

Then we choose to import images from an empty folder. The same message is written which is wrong.


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation