### PR TITLE
Fixing ssl error and broke pipe error

### DIFF
--- a/orangecontrib/imageanalytics/http2_client.py
+++ b/orangecontrib/imageanalytics/http2_client.py
@@ -15,6 +15,7 @@ from hyper.http20.exceptions import StreamResetError
 
 import hyper.http20.stream
 from .hyper import stream as local_stream
+from ssl import SSLError
 
 log = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class Http2Client(object):
         if self._server_connection:
             try:
                 self._server_connection.close()
-            except ConnectionError:
+            except (ConnectionError, SSLError):
                 log.error("Error when disconnecting from server", exc_info=True)
 
         self._server_connection = None

--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -215,7 +215,7 @@ class ImageEmbedder(Http2Client):
                     embeddings = self._send_to_server(
                         b_images, image_processed_callback, repeats_counter
                     )
-                except MaxNumberOfRequestsError:
+                except (MaxNumberOfRequestsError, BrokenPipeError):
                     # maximum number of http2 requests through a single
                     # connection is exceeded and a remote peer has closed
                     # the connection so establish a new connection and retry


### PR DESCRIPTION
##### Issue

SSL error happens sometimes on disconnection from the server. I assume that connection is broken already due to problems with hyper. 
Broken pipe error happens rarely on request to the server.  

##### Description of changes

We catch booth error since we assume that this is an error in communication with the server and not a bug in orange3-image-analytics. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation