### PR TITLE
Fix: fixing url path joining

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
     - pip install --only-binary numpy,scipy,scikit-learn numpy scipy scikit-learn
 
     - if [[ "${PYQT4}" == true ]]; then source $TRAVIS_BUILD_DIR/.travis/install_pyqt.sh; fi
-    - if [[ "${PYQT5}" == true ]]; then pip install PyQt5; fi
+    - if [[ "${PYQT5}" == true ]]; then pip install PyQt5!=5.10; fi
 
     - source $TRAVIS_BUILD_DIR/.travis/install_orange.sh
     - pip install -e .


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
There was bug joining URL path on Windows since Python's io.path.join joins paths with `\` istead with `/`

##### Description of changes

Fixed URL path joining to always use `/`

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation