### PR TITLE
Fix Orange3 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # change when release >0.7.0 of hyper will be available
 hypertemp
 numpy>=1.10.0
-Orange3>=3.3.5
+Orange3>=3.6.0
 Pillow>=4.2.1
 requests
 cachecontrol


### PR DESCRIPTION
##### Issue
Imageanalytics needs Orange 3.6.0+.

https://sentry.io/biolab/orange3-imageanalytics/issues/518529278/

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation