### PR TITLE
Fix imagegrid compatibility with older numpy.

### DIFF
--- a/orangecontrib/imageanalytics/image_grid.py
+++ b/orangecontrib/imageanalytics/image_grid.py
@@ -187,7 +187,7 @@ class ImageGrid:
             row_indices, col_indices = linear_sum_assignment(cost_matrix)
             cost = cost_matrix[row_indices, col_indices].sum()
 
-            grid_indices = np.full((self.size_x * self.size_y), -1)
+            grid_indices = np.full((self.size_x * self.size_y), -1, dtype=np.int32)
             grid_indices[row_indices] = col_indices
             assignments = grid[row_indices]
 


### PR DESCRIPTION
##### Issue
Imagegrid tests fail with numpy 1.11.2.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation