### PR TITLE
Image Viewer: Shorten combo box for many attributes.

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimageviewer.py
+++ b/orangecontrib/imageanalytics/widgets/owimageviewer.py
@@ -933,6 +933,8 @@ class OWImageViewer(widget.OWWidget):
             addSpace=True
         )
 
+        self.titleAttrCB.setStyleSheet("combobox-popup: 0;")
+
         gui.hSlider(
             self.controlArea, self, "imageSize",
             box="Image Size", minValue=32, maxValue=1024, step=16,


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Combo boxes extend across the entire screen when data has many attributes.

##### Description of changes
Shorten combo boxes and use scroll instead of a giant list.

Before
<img width="858" alt="screen shot 2018-04-26 at 16 28 55" src="https://user-images.githubusercontent.com/12524972/39312112-ffa03e52-496e-11e8-9d0e-d7f1788b9f82.png">

After
<img width="860" alt="screen shot 2018-04-26 at 16 27 12" src="https://user-images.githubusercontent.com/12524972/39312127-0781beb6-496f-11e8-8a57-87caa09f81a4.png">


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation