### PR TITLE
Import images: path fix when directory dropped to combo-box

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/owimageimport.py
@@ -600,6 +600,8 @@ class OWImportImages(widget.OWWidget):
             if len(urls) == 1:
                 url = urls[0]
                 path = url.toLocalFile()
+                if path.endswith("/"):
+                    path = path[:-1]  # remove last /
                 if os.path.isdir(path):
                     return path
             return None


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Wrong path to images appears in table when images dropped to combo-box

##### Description of changes
Path fixed

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation