### PR TITLE
Embedders: Moved handling of MaxNumberOfRequestsError

### DIFF
--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -387,9 +387,10 @@ class ImageEmbedder(Http2Client):
 
             try:
                 response = self._get_json_response_or_none(stream_id)
-            except ConnectionError:
+            except (ConnectionError, MaxNumberOfRequestsError):
                 self.persist_cache()
-                raise
+                self.reconnect_to_server()
+                return embeddings
 
             if not response or 'embedding' not in response:
                 # returned response is not a valid json response


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Stop iteration error happen in the embedders widget after the connection fails during the evaluation. Embeddings for images from the batch evaluated when the connection failed were not stored but still counted as evaluated. 

##### Description of changes

Images evaluated before the connection fails are stored now. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation