### PR TITLE
Fix: Changed required version for Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 hypertemp
 numpy>=1.10.0
 Orange3>=3.6.0
-Pillow>=4.2.1
+Pillow>=4.2.1,!=5.1.0
 requests
 cachecontrol
 lockfile


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Pillow 5.1.0 does not work on some versions of MacOS.
Issue https://github.com/biolab/orange3-imageanalytics/issues/87

##### Description of changes

Requirements fixed to use a version different from 5.1.0

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation