### PR TITLE
Fixing selection colors in image grid to match other with widgets

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimagegrid.py
+++ b/orangecontrib/imageanalytics/widgets/owimagegrid.py
@@ -440,7 +440,7 @@ class OWImageGrid(widget.OWWidget):
             brushes = [no_brush, no_brush]
         else:
             palette = ColorPaletteGenerator(number_of_colors=sels + 1)
-            brushes = [no_brush] + [QBrush(palette[i + 1]) for i in range(sels)]
+            brushes = [no_brush] + [QBrush(palette[i]) for i in range(sels)]
         brush = [brushes[a] for a in self.selection]
 
         pen = [DEFAULT_SELECTION_PEN] * len(self.items)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
https://github.com/biolab/orange3-imageanalytics/issues/89

##### Description of changes

Colors for selected groups of images are changed such that they match to colors in other widgets such as MDS and Scatterplot

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation