### PR TITLE
[FIX] Image grid selection on the output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ dist: trusty
 matrix:
   include:
     - python: '3.4'
-      env: PYQT4=true ORANGE="3.6.0"
+      env: PYQT4=true ORANGE="3.7.0"
 
     - python: '3.5'
-      env: PYQT5=true ORANGE="3.6.0"
+      env: PYQT5=true ORANGE="3.7.0"
 
     - python: '3.5'
       env: PYQT5=true ORANGE="release"

--- a/orangecontrib/imageanalytics/widgets/owimagegrid.py
+++ b/orangecontrib/imageanalytics/widgets/owimagegrid.py
@@ -57,8 +57,9 @@ class OWImageGrid(widget.OWWidget):
         data_subset = Input("Data Subset", Orange.data.Table)
 
     class Outputs:
+        selected_data = Output(
+            "Selected Images", Orange.data.Table, default=True)
         data = Output("Images", Orange.data.Table)
-        selected_data = Output("Selected Images", Orange.data.Table)
 
     settingsHandler = settings.DomainContextHandler()
 
@@ -415,9 +416,13 @@ class OWImageGrid(widget.OWWidget):
             # filter out empty cells - keep only indices of cells that contain images
             # add Selected column (Yes/No if one group, else Unselected or group number)
             if self.selection is not None and np.max(self.selection) > 1:
-                out_data = create_groups_table(self.image_grid.image_list[self.nonempty], self.selection[self.nonempty])
+                out_data = create_groups_table(
+                    self.image_grid.image_list[self.nonempty],
+                    self.selection[self.nonempty])
             else:
-                out_data = create_annotated_table(self.image_grid.image_list[self.nonempty], self.selection[self.nonempty])
+                out_data = create_annotated_table(
+                    self.image_grid.image_list[self.nonempty],
+                    np.nonzero(self.selection[self.nonempty]))
             self.Outputs.data.send(out_data)
 
         else:

--- a/orangecontrib/imageanalytics/widgets/owimagegrid.py
+++ b/orangecontrib/imageanalytics/widgets/owimagegrid.py
@@ -411,10 +411,12 @@ class OWImageGrid(widget.OWWidget):
         if self.data:
             # add Group column (group number)
             self.Outputs.selected_data.send(
-                create_groups_table(self.image_grid.image_list, self.selection, False, "Group"))
+                create_groups_table(self.image_grid.image_list, self.selection,
+                                    False, "Group"))
 
-            # filter out empty cells - keep only indices of cells that contain images
-            # add Selected column (Yes/No if one group, else Unselected or group number)
+            # filter out empty cells - keep indices of cells that contain images
+            # add Selected column
+            # (Yes/No if one group, else Unselected or group number)
             if self.selection is not None and np.max(self.selection) > 1:
                 out_data = create_groups_table(
                     self.image_grid.image_list[self.nonempty],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # change when release >0.7.0 of hyper will be available
 hypertemp
 numpy>=1.10.0
-Orange3>=3.6.0
+Orange3>=3.7.0
 Pillow>=4.2.1,!=5.1.0
 requests
 cachecontrol


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
https://github.com/biolab/orange3-imageanalytics/issues/108
Selectied variable in the output data does not show the selected images correctly

##### Description of changes
Selected variable in output data fixed to mark correct image
`Selected images` set as a default output.
The lowest suported version of Orange incraset to 3.7

##### Includes
- [X] Code changes
- [ ] Tests
- [x] Documentation