### PR TITLE
Embedders widget - field for a custom server URL

### DIFF
--- a/orangecontrib/imageanalytics/http2_client.py
+++ b/orangecontrib/imageanalytics/http2_client.py
@@ -31,7 +31,10 @@ class Http2Client(object):
 
     def __init__(self, server_url):
         self._server_url = getenv('ORANGE_EMBEDDING_API_URL', server_url)
-        self._server_connection = self._connect_to_server()
+        try:
+            self._server_connection = self._connect_to_server()
+        except:
+            raise ConnectionError
         self._max_concurrent_streams = self._read_max_concurrent_streams()
 
     def reconnect_to_server(self):

--- a/orangecontrib/imageanalytics/widgets/owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/owimageembedding.py
@@ -69,7 +69,7 @@ class OWImageEmbedding(OWWidget):
             self, threadPool=QThreadPool(maxThreadCount=1)
         )
         self.setBlocking(True)
-        QTimer.singleShot(0, self._init_server_connection)
+        QTimer.singleShot(0, self.changed_server_url)
 
     def _setup_layout(self):
         self.controlArea.setMinimumWidth(self.controlArea.sizeHint().width())

--- a/orangecontrib/imageanalytics/widgets/tests/test_owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/tests/test_owimageembedding.py
@@ -75,3 +75,22 @@ class TestOWImageEmbedding(WidgetTest):
         self.assertEqual(type(skipped), DummyCorpus)
         self.assertEqual(len(skipped), len(table))
 
+
+    def test_url_changed(self):
+        """
+        This test set if the urls are changed correctly
+        The test may fail if default url will be changed
+        """
+        w = self.widget
+
+        w.use_custom_server_cb.setChecked(False)
+        self.assertEqual(w._image_embedder._server_url, w.SERVER_URL_DEFAULT)
+
+        w.use_custom_server_cb.setChecked(True)
+        w.server_url_box.setText("")
+        w.changed_server_url()
+
+        w.use_custom_server_cb.setChecked(True)
+        w.server_url_box.setText(w.SERVER_URL_DEFAULT)
+        w.changed_server_url()
+        self.assertEqual(w._image_embedder._server_url, w.SERVER_URL_DEFAULT)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
No possibility to set custom server url.

##### Description of changes

Adding a field and functionality for a custom URL set.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation