### PR TITLE
[WIP] FIX: OWImageEmbedding outputs Corpus when Corpus on the input

### DIFF
--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -427,23 +427,20 @@ class ImageEmbedder(Http2Client):
 
     @staticmethod
     def construct_output_data_table(embedded_images, embeddings):
-        if sparse.issparse(embedded_images.X):
-            X = util.hstack((embedded_images.X, embeddings))
-        else:
-            X = util.hstack((embedded_images.X, embeddings))
-        Y = embedded_images.Y
+        # X = util.hstack((embedded_images.X, embeddings))
+        # embedded_images.X = X
 
-        attributes = [ContinuousVariable.make('n{:d}'.format(d))
+        new_attributes = [ContinuousVariable.make('n{:d}'.format(d))
                       for d in range(embeddings.shape[1])]
-        attributes = list(embedded_images.domain.attributes) + attributes
 
-        domain = Domain(
-            attributes=attributes,
-            class_vars=embedded_images.domain.class_vars,
-            metas=embedded_images.domain.metas
-        )
 
-        return Table(domain, X, Y, embedded_images.metas)
+        domain_new = Domain(list(embedded_images.domain.attributes) + new_attributes,
+                        embedded_images.domain.class_vars,
+                        embedded_images.domain.metas)
+        table = embedded_images.transform(domain_new)
+        table[:, new_attributes] = embeddings
+
+        return table
 
     @staticmethod
     def prepare_output_data(input_data, embeddings):

--- a/orangecontrib/imageanalytics/widgets/tests/test_owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/tests/test_owimageembedding.py
@@ -7,9 +7,13 @@ from AnyQt.QtGui import QDropEvent, QDragEnterEvent
 from AnyQt.QtWidgets import QApplication
 from AnyQt.QtTest import QTest, QSignalSpy
 
-from Orange.data import Table
+from Orange.data import Table, Domain
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from orangecontrib.imageanalytics.widgets.owimageembedding import OWImageEmbedding
+
+
+class DummyCorpus(Table):
+    pass
 
 
 class TestOWImageEmbedding(WidgetTest):
@@ -40,3 +44,21 @@ class TestOWImageEmbedding(WidgetTest):
         table = Table("iris")[:0]
         self.send_signal("Images", table)
         self.send_signal("Images", None)
+
+    def test_data_corpus(self):
+        table = DummyCorpus("zoo-with-images")[::3]
+
+        self.send_signal("Images", table)
+        results = self.get_output("Embeddings")
+
+        self.assertEqual(type(results), DummyCorpus)  # check if output right type
+        self.assertEqual(len(results), len(table))
+
+    def test_data_regular_table(self):
+        table = Table("zoo-with-images")[::3]
+
+        self.send_signal("Images", table)
+        results = self.get_output("Embeddings")
+
+        self.assertEqual(type(results), Table)  # check if output right type
+        self.assertEqual(len(results), len(table))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
OWImageEmbedding does not output Corpus when Corpus on the input

##### Description of changes
OWImageEmbedding fixed that outputs Corpus when Corpus on the input

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation