### PR TITLE
Import Images: Find data if in the same folder as workflow

### DIFF
--- a/orangecontrib/imageanalytics/widgets/tests/test_owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/tests/test_owimageimport.py
@@ -76,6 +76,7 @@ class TestOWImageImport(unittest.TestCase):
             assert QApplication.sendEvent(widget.recent_cb, ev)
             self.assertTrue(ev.isAccepted())
             del ev
-            self.assertEqual(widget.currentPath, urlpath.toLocalFile())
+            self.assertEqual(widget.recent_paths[0].abspath,
+                             urlpath.toLocalFile())
             self._startandwait(widget)
             self.widget.commit()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
https://github.com/biolab/orange3-imageanalytics/issues/102

##### Description of changes
Changed the widget that it uses the relative paths and change the absolute path in a case when workflow environment changes. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation