### PR TITLE
Updated travis virtual machine to Ubuntu 16.04 Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 sudo: false   # use container-based infrastructure
-dist: trusty
+dist: xenial
 
 matrix:
   include:

--- a/orangecontrib/imageanalytics/widgets/tests/test_owimageviewer.py
+++ b/orangecontrib/imageanalytics/widgets/tests/test_owimageviewer.py
@@ -4,7 +4,7 @@ from Orange.widgets.tests.base import WidgetTest
 from orangecontrib.imageanalytics.widgets.owimageviewer import OWImageViewer
 
 
-class TestOWImageEmbedding(WidgetTest):
+class TestOWImageViewer(WidgetTest):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
dlopen: cannot load any more object with static TLS in Travis unittests.

##### Description of changes

- Xenial has a larger slot for objects with static TLS
- Tests cleanup

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation