### PR TITLE
Inception default and force to switch to local embedder when no connection to the server

### DIFF
--- a/orangecontrib/imageanalytics/http2_client.py
+++ b/orangecontrib/imageanalytics/http2_client.py
@@ -1,5 +1,6 @@
 import json
 from urllib.parse import urlparse
+import os
 
 try:
     from json.decoder import JSONDecodeError
@@ -104,7 +105,10 @@ class Http2Client(object):
         """
         url = self._server_url.split(":")[0]
         if url is not None:
-            response = system("ping -c 1 " + url)
+            if os.name == 'nt':
+                response = system("ping %s -n 2" % url)
+            else:
+                response = system("ping -c 2 " + url)
             return response == 0
         else:
             return False

--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -186,9 +186,10 @@ class ImageEmbedder:
         metas = data.domain.metas
         return [m for m in metas if m.attributes.get('type') == 'image']
 
-    def is_connected_to_server(self):
+    def is_connected_to_server(self, use_hyper=True):
         if not self.is_local_embedder():
-            return self._embedder.is_connected_to_server()
+            return self._embedder.is_connected_to_server() if use_hyper else \
+                self._embedder.ping_server()
         else:
             return False
 

--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -10,7 +10,7 @@ MODELS = {
         'description': 'Google\'s Inception v3 model trained on ImageNet.',
         'target_image_size': (299, 299),
         'layers': ['penultimate'],
-        'order': 1
+        'order': 0
     },
     'painters': {
         'name': 'Painters',
@@ -56,7 +56,7 @@ MODELS = {
                        '50x fewer parameters.',
         'target_image_size': (227, 227),
         'layers': ['penultimate'],
-        'order': 0,
+        'order': 1,
         'is_local': True,
         'batch_size': 16
     }

--- a/orangecontrib/imageanalytics/widgets/owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/owimageembedding.py
@@ -173,7 +173,7 @@ class OWImageEmbedding(OWWidget):
         """
         self.Warning.switched_local_embedder.clear()
         if not self._image_embedder.is_local_embedder() and \
-            not self._image_embedder.is_connected_to_server():
+            not self._image_embedder.is_connected_to_server(use_hyper=False):
             # switching to local embedder
             self.Warning.switched_local_embedder()
             self.cb_embedder_current_id = self.embedders.index("squeezenet")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Squeezenet default - limited statistcs.
When no connection to the server remote embedders will not work.

##### Description of changes
Set Inception as a default. 
When no connection switched to local embedder. Switching is made only when new data at the input. When old data present they can be evaluated with the same embedder due to the local cache. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation