### PR TITLE
Fix: Check paths match when directory changed correctly.

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/owimageimport.py
@@ -341,7 +341,7 @@ class OWImportImages(widget.OWWidget):
         """
         if self.recent_paths and path is not None and \
                 os.path.isdir(self.recent_paths[0].abspath) and os.path.isdir(path) \
-                and os.path.samefile(os.path.isdir(self.recent_paths[0].abspath), path):
+                and os.path.samefile(self.recent_paths[0].abspath, path):
             return True
 
         success = True


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Import images widget chrashes when a selected directory changes in Import images widget.

##### Description of changes
There seems to be a bug in the if-clause and was fixed. Removed redundant code.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation