### PR TITLE
[MERGE December 2019] Remove old previewbroser import

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/owimageimport.py
@@ -35,13 +35,8 @@ from Orange.widgets.utils.filedialogs import RecentPath
 from Orange.widgets.utils.concurrent import (
     ThreadExecutor, FutureWatcher, methodinvoke
 )
-
-try:
-    from orangecanvas.preview.previewbrowser import TextLabel
-except ImportError:
-    from Orange.canvas.preview.previewbrowser import TextLabel
-
 from Orange.widgets.utils.signals import Output
+from orangecanvas.preview.previewbrowser import TextLabel
 
 from orangecontrib.imageanalytics.import_images import ImportImages
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # change when release >0.7.0 of hyper will be available
 hypertemp
 numpy>=1.13.0
-Orange3>=3.7.0
+Orange3>=3.23.0
 Pillow>=4.2.1,!=5.1.0
 requests
 cachecontrol


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
After switching on orangecanvas previewbrowser import changed. Fix #130 tried to import old and new import in order to support older Orange versions. 

##### Description of changes

I think that in October 2019 supporting older Orange versions than 3.23 is not required anymore. So we remove an old import.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation