### PR TITLE
Fix version of numpy to 1.16.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,10 @@ before_install:
     - pip install codecov
 
 install:
-    - pip install --only-binary numpy,scipy,scikit-learn numpy scipy scikit-learn
+    # todo: numpy limited to 1.16 since there is an issue with version 1.17.*
+    # and 1.15.* remove this limitation after while, also remove the limitation
+    # requirements
+    - pip install --only-binary numpy,scipy,scikit-learn numpy==1.16.* scipy scikit-learn
     - pip install sip pyqt5==5.11.*
     - source $TRAVIS_BUILD_DIR/.travis/install_orange.sh
     - pip install -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # change when release >0.7.0 of hyper will be available
 hypertemp
-numpy>=1.13.0
+numpy==1.16.*
 Orange3>=3.20.0
 Pillow>=4.2.1,!=5.1.0
 requests


### PR DESCRIPTION
##### Issue
tSNE import fails due to issues with numpy versions.

##### Description of changes

Numpy temporarily fixed to version 1.16.*

##### Includes
- [ ] Code changes
- [x] Tests
- [ ] Documentation