### PR TITLE
Embedder: Drop long descriptions in more lines

### DIFF
--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -15,7 +15,7 @@ MODELS = {
     'painters': {
         'name': 'Painters',
         'description':
-            'A model trained to predict painters from artwork images.',
+            'A model trained to predict painters from artwork\nimages.',
         'target_image_size': (256, 256),
         'layers': ['penultimate'],
         'order': 4
@@ -29,21 +29,21 @@ MODELS = {
     },
     'vgg16': {
         'name': 'VGG-16',
-        'description': '16-layer image recognition model trained on ImageNet.',
+        'description': '16-layer image recognition model trained on\nImageNet.',
         'target_image_size': (224, 224),
         'layers': ['penultimate'],
         'order': 2
     },
     'vgg19': {
         'name': 'VGG-19',
-        'description': '19-layer image recognition model trained on ImageNet.',
+        'description': '19-layer image recognition model trained on\nImageNet.',
         'target_image_size': (224, 224),
         'layers': ['penultimate'],
         'order': 3
     },
     'openface': {
         'name': 'openface',
-        'description': 'Face recognition model trained on FaceScrub and '
+        'description': 'Face recognition model trained on FaceScrub and\n'
                        'CASIA-WebFace datasets.',
         'target_image_size': (256, 256),
         'layers': ['penultimate'],


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Some descriptions of embedders are too long and make widget too wide. 

##### Description of changes

Longer descriptions are dropped in more lines. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation