### PR TITLE
Shortened widget run in `__main__`

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/owimageimport.py
@@ -657,24 +657,6 @@ class UserInterruptError(BaseException):
     pass
 
 
-def main(argv=sys.argv):
-    app = QApplication(list(argv))
-    argv = app.arguments()
-    if len(argv) > 1:
-        path = argv[1]
-    else:
-        path = None
-    w = OWImportImages()
-    w.show()
-    w.raise_()
-
-    if path is not None:
-        w.setCurrentPath(path)
-
-    app.exec_()
-    w.saveSettings()
-    w.onDeleteWidget()
-    return 0
-
 if __name__ == "__main__":
-    sys.exit(main())
+    from orangewidget.utils.widgetpreview import WidgetPreview
+    WidgetPreview(OWImportImages).run()

--- a/orangecontrib/imageanalytics/widgets/owimageviewer.py
+++ b/orangecontrib/imageanalytics/widgets/owimageviewer.py
@@ -1485,28 +1485,8 @@ class ImageLoader(QObject):
         return future
 
 
-def main(argv=sys.argv):
-    import sip
-    logging.basicConfig(level=logging.DEBUG)
-    app = QApplication(argv)
-    argv = app.arguments()
-    w = OWImageViewer()
-    w.show()
-    w.raise_()
-
-    if len(argv) > 1:
-        data = Orange.data.Table(argv[1])
-    else:
-        data = Orange.data.Table('zoo-with-images')
-
-    w.setData(data)
-    rval = app.exec_()
-    w.saveSettings()
-    w.onDeleteWidget()
-    sip.delete(w)
-    app.processEvents()
-    return rval
-
-
 if __name__ == "__main__":
-    main()
+    from orangewidget.utils.widgetpreview import WidgetPreview
+    from Orange.data import Table
+    WidgetPreview(OWImageViewer).run(
+        Table("https://datasets.biolab.si/core/bone-healing.xlsx"))

--- a/orangecontrib/imageanalytics/widgets/owsaveimages.py
+++ b/orangecontrib/imageanalytics/widgets/owsaveimages.py
@@ -399,4 +399,4 @@ class OWSaveImages(OWWidget, ConcurrentWidgetMixin):
 
 if __name__ == "__main__":  # pragma: no cover
     WidgetPreview(OWSaveImages).run(
-        Table("https://datasets.biolab.si//core/bone-healing.xlsx"))
+        Table("https://datasets.biolab.si/core/bone-healing.xlsx"))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Widgets have complicated part of the script for running widget directly and it is not working since the dataset is missing

##### Description of changes
Simplifying running the widgets with `WidgetPreview`

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation