### PR TITLE
Image Embedder: Use Variable.make

### DIFF
--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -165,7 +165,7 @@ class ImageEmbedder:
 
     @staticmethod
     def construct_output_data_table(embedded_images, embeddings):
-        new_attributes = [ContinuousVariable('n{:d}'.format(d))
+        new_attributes = [ContinuousVariable.make('n{:d}'.format(d))
                           for d in range(embeddings.shape[1])]
         # prevent embeddings to be shown in long drop-downs in e.g. scatterplot
         for a in new_attributes:


### PR DESCRIPTION
##### Issue

Embedder does not use Variable.make, so variables from different embeddings are incompatible. This problem occurs only on older versions of Orange, which still use make.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation