### PR TITLE
ImageGrid: subset matches on attrs not metas

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimagegrid.py
+++ b/orangecontrib/imageanalytics/widgets/owimagegrid.py
@@ -336,7 +336,8 @@ class OWImageGrid(widget.OWWidget):
 
         if self.data and self.data_subset:
             transformed = self.data_subset.transform(self.data.domain)
-            if np.all(self.data.domain.metas == self.data_subset.domain.metas):
+            if np.all(self.data.domain.attributes ==
+                      self.data_subset.domain.attributes):
                 indices = {e.id for e in transformed}
                 self.subset_indices = [ex.id in indices for ex in self.data]
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Subset in ImageGrid for some reason matched on metas, so subsets from Confusion Matrix didn't work.

##### Description of changes
Subset now checks attributes.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation