### PR TITLE
ImageGrid: remove wrong subset condition

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimagegrid.py
+++ b/orangecontrib/imageanalytics/widgets/owimagegrid.py
@@ -336,13 +336,11 @@ class OWImageGrid(widget.OWWidget):
 
         if self.data and self.data_subset:
             transformed = self.data_subset.transform(self.data.domain)
-            if np.all(self.data.domain.metas == self.data_subset.domain.metas):
-                indices = {e.id for e in transformed}
-                self.subset_indices = [ex.id in indices for ex in self.data]
+            indices = {e.id for e in transformed}
+            self.subset_indices = [ex.id in indices for ex in self.data]
 
-            else:
-                self.Warning.incompatible_subset()
-
+            # else:
+            #     self.Warning.incompatible_subset()
         self.apply_subset()
 
     def url_from_value(self, value):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
ImageGrid wrongly check whether the subset matches the original data when another attribute present in mteas it does not work.

##### Description of changes
Temporarily removing the wrong condition. It will be replaced with the better one that really checks the subset.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation