### PR TITLE
Image Viewer: move info to status bar; resolve deprecation warnings across the add-on

### DIFF
--- a/orangecontrib/imageanalytics/image_grid.py
+++ b/orangecontrib/imageanalytics/image_grid.py
@@ -21,7 +21,7 @@ class ImageGrid:
         self.data = data
 
         # reduce dimensions
-        data_2dim = Table(self._reduce_dimensions(data))
+        data_2dim = Table.from_numpy(None, self._reduce_dimensions(data))
 
         # normalize the data
         self.norm_data = np.array(self._normalize_data(data_2dim))
@@ -195,7 +195,7 @@ class ImageGrid:
 
     def _grid_indices_to_image_list(self, images):
         """
-        Return the image grid as a Table of images, ordered by rows. 
+        Return the image grid as a Table of images, ordered by rows.
         If a grid cell does not contain an image, put None in its place.
 
         Parameters

--- a/orangecontrib/imageanalytics/import_images.py
+++ b/orangecontrib/imageanalytics/import_images.py
@@ -229,7 +229,7 @@ def create_table(image_meta, categories=None, start_dir=None):
             )
         else:
             # empty results, no images found
-            table = Orange.data.Table(domain)
+            table = Orange.data.Table.from_domain(domain)
     else:
         table = None
 

--- a/orangecontrib/imageanalytics/widgets/owimageviewer.py
+++ b/orangecontrib/imageanalytics/widgets/owimageviewer.py
@@ -952,10 +952,6 @@ class OWImageViewer(widget.OWWidget):
         self._errcount = 0
         self._successcount = 0
 
-        self.info = gui.widgetLabel(
-            gui.vBox(self.controlArea, "Info"),
-            "Waiting for input.\n"
-        )
         self.imageAttrCB = gui.comboBox(
             self.controlArea, self, "imageAttr",
             box="Image Filename Attribute",
@@ -1001,6 +997,7 @@ class OWImageViewer(widget.OWWidget):
     def setData(self, data):
         self.closeContext()
         self.clear()
+        self.info.set_output_summary(self.info.NoOutput)
         self.data = data
 
         if data is not None:
@@ -1030,7 +1027,8 @@ class OWImageViewer(widget.OWWidget):
             if self.stringAttrs:
                 self.setupScene()
         else:
-            self.info.setText("Waiting for input.\n")
+            self.info.set_input_summary(self.info.NoInput)
+            self.info.set_output_summary(self.info.NoOutput)
         self.commit()
 
     def clear(self):
@@ -1111,6 +1109,9 @@ class OWImageViewer(widget.OWWidget):
     def onSelectionChanged(self):
         selected = [item for item in self.items if item.widget.isSelected()]
         self.selectedIndices = [item.index for item in selected]
+        self.info.set_output_summary(
+            str(len(self.selectedIndices)),
+            f"{len(self.selectedIndices)} images selected")
         self.commit()
 
     def commit(self):
@@ -1145,7 +1146,7 @@ class OWImageViewer(widget.OWWidget):
 
         if self._errcount:
             text += f"{self._errcount} errors."
-        self.info.setText(text)
+        self.info.set_input_summary(str(count), text)
         attr = self.stringAttrs[self.imageAttr]
         if self._errcount == count and "type" not in attr.attributes:
             self.error("No images could be ! Make sure the '%s' attribute "

--- a/orangecontrib/imageanalytics/widgets/tests/test_owimageviewer.py
+++ b/orangecontrib/imageanalytics/widgets/tests/test_owimageviewer.py
@@ -1,7 +1,14 @@
-from Orange.data import Table
+from os import path
+from unittest.mock import Mock
+import numpy as np
+
+from Orange.data import Table, StringVariable, Domain
 from Orange.widgets.tests.base import WidgetTest
 
 from orangecontrib.imageanalytics.widgets.owimageviewer import OWImageViewer
+
+
+IMAGES = ['example_image_0.jpg', 'example_image_1.tiff', 'example_image_2.png']
 
 
 class TestOWImageViewer(WidgetTest):
@@ -11,6 +18,15 @@ class TestOWImageViewer(WidgetTest):
 
     def setUp(self):
         self.widget = self.create_widget(OWImageViewer)
+
+        # generate table with images
+        str_var = StringVariable("Image")
+        str_var.attributes["origin"] = path.dirname(
+            path.abspath(path.join(__file__, "..", "..", "tests")))
+        self.image_data = Table(
+            Domain([], [], metas=[str_var]),
+            np.empty((3, 0)), np.empty((3, 0)),
+            metas=[[img] for img in IMAGES])
 
     def test_output(self):
         table = Table("iris")[::5]
@@ -33,3 +49,27 @@ class TestOWImageViewer(WidgetTest):
         self.send_signal("Data", None)
         self.assertIsNone(self.get_output(self.widget.Outputs.data))
         self.assertIsNone(self.get_output(self.widget.Outputs.selected_data))
+
+    def test_info_input(self):
+        input_sum = self.widget.info.set_input_summary = Mock()
+
+        self.send_signal(self.widget.Inputs.data, self.image_data)
+        input_sum.assert_called_with(
+            str(len(self.image_data)), '0 of 3 images displayed.\n')
+
+        self.send_signal(self.widget.Inputs.data, None)
+        input_sum.assert_called_with(self.widget.info.NoInput)
+
+    def test_info_output(self):
+        output_sum = self.widget.info.set_output_summary = Mock()
+
+        self.send_signal(self.widget.Inputs.data, self.image_data)
+        output_sum.assert_called_with(self.widget.info.NoOutput)
+
+        self.send_signal(self.widget.Inputs.data, None)
+        output_sum.assert_called_with(self.widget.info.NoOutput)
+
+        self.send_signal(self.widget.Inputs.data, self.image_data)
+        for itm in self.widget.items[:3]:
+            itm.widget.setSelected(True)
+        output_sum.assert_called_with("3", "3 images selected")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
There were few deprecation warning appearing in the addon.
Image Viewer overrides self.info

##### Description of changes
- Resolve deprecation warnings
- Since info, in general, are moved to status bar elsewhere in Orange it is done here too.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation