### PR TITLE
Travis: raise minimum Orange version for testing to 3.25.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   include:
 
     - python: '3.7'
-      env: ORANGE="3.25.0"
+      env: ORANGE="3.25.1"
 
     - python: '3.6'
       env: ORANGE="release"


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Travis started to fail because of scikit-orange-issue which is fixed in 3.25.1

##### Description of changes
There is no other option than to raise the minimum version of Orange in Travis
