### PR TITLE
Add tf inception v3

### DIFF
--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -7,7 +7,6 @@ import numpy as np
 from Orange.data import ContinuousVariable, Domain, Table, Variable
 from Orange.misc.utils.embedder_utils import EmbedderCache
 
-from orangecontrib.imageanalytics.local_embedders.inception_v3 import InceptionV3Embedder
 from orangecontrib.imageanalytics.local_embedders.squeez_net import SqueezeNetEmbedder
 from orangecontrib.imageanalytics.server_embedder import ServerEmbedder
 
@@ -23,20 +22,6 @@ MODELS = {
         # send less images since bottleneck are workers, this way we avoid
         # ReadTimeout because of images waiting in a queue at the server
         "batch_size": 100,
-    },
-    "tf-inception-v3": {
-        "name": "Local Inception v3",
-        "description": "Local Google's Inception v3 model trained on ImageNet.",
-        "target_image_size": (299, 299),
-        "layers": ["penultimate"],
-        "order": 0,
-        # batch size tell how many images we send in parallel, this number is
-        # high for inception since it has many workers, but other embedders
-        # send less images since bottleneck are workers, this way we avoid
-        # ReadTimeout because of images waiting in a queue at the server
-        "is_local": True,
-        "batch_size": 100,
-        "model_cls": InceptionV3Embedder
     },
     "painters": {
         "name": "Painters",
@@ -93,6 +78,27 @@ MODELS = {
     },
 }
 
+try:
+
+    import tensorflow
+    from orangecontrib.imageanalytics.local_embedders.inception_v3 import InceptionV3Embedder
+    
+    MODELS["tf-inception-v3"] = {
+        "name": "Local Inception v3",
+        "description": "Local Google's Inception v3 model trained on ImageNet.",
+        "target_image_size": (299, 299),
+        "layers": ["penultimate"],
+        "order": 0,
+        # batch size tell how many images we send in parallel, this number is
+        # high for inception since it has many workers, but other embedders
+        # send less images since bottleneck are workers, this way we avoid
+        # ReadTimeout because of images waiting in a queue at the server
+        "is_local": True,
+        "batch_size": 100,
+        "model_cls": InceptionV3Embedder
+    }
+except ModuleNotFoundError:
+    pass
 
 class ImageEmbedder:
     """

--- a/orangecontrib/imageanalytics/local_embedders/__init__.py
+++ b/orangecontrib/imageanalytics/local_embedders/__init__.py
@@ -1,0 +1,3 @@
+import os
+os.environ["CUDA_DEVICE_ORDER"]="PCI_BUS_ID"
+os.environ["CUDA_VISIBLE_DEVICES"]=""

--- a/orangecontrib/imageanalytics/local_embedders/inception_v3.py
+++ b/orangecontrib/imageanalytics/local_embedders/inception_v3.py
@@ -1,48 +1,53 @@
-import tarfile
-from pathlib import Path
-from urllib import request
+try:
+    import tensorflow
+    import tarfile
+    from pathlib import Path
+    from urllib import request
 
-from numpy import squeeze
-from tensorflow.compat import v1 as tf1
-from tensorflow.python.platform import gfile
+    from numpy import squeeze
+    from tensorflow.compat import v1 as tf1
+    from tensorflow.python.platform import gfile
 
-from orangecontrib.imageanalytics.local_embedders.local_embedder import LocalEmbedder, MODELS_DIR
-
-
-class InceptionV3Embedder(LocalEmbedder):
-
-    embedder = None
-    model_checkpoint_filename = "classify_image_graph_def.pb"
-    model_url = "http://download.tensorflow.org/models/image/imagenet/inception-2015-12-05.tgz"
-
-    def _download_model(self, model_dir, output_file):
-        model_tar = model_dir/Path("inception-2015-12-05.tgz")
-        request.urlretrieve(url=self.model_url, filename=model_tar)
-        with tarfile.open(model_tar, "r:gz") as tar_file:
-            tar_file.extract(output_file, model_dir)
-        assert (model_dir/Path(output_file)).exists(), "Failed to download file"
-
-    def get_model(self):
-
-        model_dir = Path.home() / MODELS_DIR / Path("inception-v3")
-        model_dir.mkdir(parents=True, exist_ok=True)
-        model_path = model_dir / Path(self.model_checkpoint_filename)
-        if not model_path.exists():
-            self._download_model(model_dir, self.model_checkpoint_filename)
-
-        return model_path
+    from orangecontrib.imageanalytics.local_embedders.local_embedder import LocalEmbedder, MODELS_DIR
 
 
-    def _load_model(self):
-        tf1.disable_v2_behavior()
-        model_path = self.get_model()
-        with gfile.FastGFile(str(model_path), 'rb') as f:
-            graph_def = tf1.GraphDef()
-            graph_def.ParseFromString(f.read())
-        tf1.import_graph_def(graph_def, name='')
-        sess = tf1.Session()
-        embed_tensor = sess.graph.get_tensor_by_name('pool_3:0')
-        self.embedder = lambda images: squeeze(sess.run(embed_tensor, {'DecodeJpeg/contents:0': images}))
+    class InceptionV3Embedder(LocalEmbedder):
 
-    def _load_image(self, image_path):
-        return gfile.FastGFile(image_path, 'rb').read()
+        embedder = None
+        model_checkpoint_filename = "classify_image_graph_def.pb"
+        model_url = "http://download.tensorflow.org/models/image/imagenet/inception-2015-12-05.tgz"
+
+        def _download_model(self, model_dir, output_file):
+            model_tar = model_dir/Path("inception-2015-12-05.tgz")
+            request.urlretrieve(url=self.model_url, filename=model_tar)
+            with tarfile.open(model_tar, "r:gz") as tar_file:
+                tar_file.extract(output_file, model_dir)
+            assert (model_dir/Path(output_file)).exists(), "Failed to download file"
+
+        def get_model(self):
+
+            model_dir = Path.home() / MODELS_DIR / Path("inception-v3")
+            model_dir.mkdir(parents=True, exist_ok=True)
+            model_path = model_dir / Path(self.model_checkpoint_filename)
+            if not model_path.exists():
+                self._download_model(model_dir, self.model_checkpoint_filename)
+
+            return model_path
+
+
+        def _load_model(self):
+            tf1.disable_v2_behavior()
+            model_path = self.get_model()
+            with gfile.FastGFile(str(model_path), 'rb') as f:
+                graph_def = tf1.GraphDef()
+                graph_def.ParseFromString(f.read())
+            tf1.import_graph_def(graph_def, name='')
+            sess = tf1.Session()
+            embed_tensor = sess.graph.get_tensor_by_name('pool_3:0')
+            self.embedder = lambda images: squeeze(sess.run(embed_tensor, {'DecodeJpeg/contents:0': images}))
+
+        def _load_image(self, image_path):
+            return gfile.FastGFile(image_path, 'rb').read()
+
+except ModuleNotFoundError:
+    pass

--- a/orangecontrib/imageanalytics/local_embedders/inception_v3.py
+++ b/orangecontrib/imageanalytics/local_embedders/inception_v3.py
@@ -1,0 +1,48 @@
+import tarfile
+from pathlib import Path
+from urllib import request
+
+from numpy import squeeze
+from tensorflow.compat import v1 as tf1
+from tensorflow.python.platform import gfile
+
+from orangecontrib.imageanalytics.local_embedders.local_embedder import LocalEmbedder, MODELS_DIR
+
+
+class InceptionV3Embedder(LocalEmbedder):
+
+    embedder = None
+    model_checkpoint_filename = "classify_image_graph_def.pb"
+    model_url = "http://download.tensorflow.org/models/image/imagenet/inception-2015-12-05.tgz"
+
+    def _download_model(self, model_dir, output_file):
+        model_tar = model_dir/Path("inception-2015-12-05.tgz")
+        request.urlretrieve(url=self.model_url, filename=model_tar)
+        with tarfile.open(model_tar, "r:gz") as tar_file:
+            tar_file.extract(output_file, model_dir)
+        assert (model_dir/Path(output_file)).exists(), "Failed to download file"
+
+    def get_model(self):
+
+        model_dir = Path.home() / MODELS_DIR / Path("inception-v3")
+        model_dir.mkdir(parents=True, exist_ok=True)
+        model_path = model_dir / Path(self.model_checkpoint_filename)
+        if not model_path.exists():
+            self._download_model(model_dir, self.model_checkpoint_filename)
+
+        return model_path
+
+
+    def _load_model(self):
+        tf1.disable_v2_behavior()
+        model_path = self.get_model()
+        with gfile.FastGFile(str(model_path), 'rb') as f:
+            graph_def = tf1.GraphDef()
+            graph_def.ParseFromString(f.read())
+        tf1.import_graph_def(graph_def, name='')
+        sess = tf1.Session()
+        embed_tensor = sess.graph.get_tensor_by_name('pool_3:0')
+        self.embedder = lambda images: squeeze(sess.run(embed_tensor, {'DecodeJpeg/contents:0': images}))
+
+    def _load_image(self, image_path):
+        return gfile.FastGFile(image_path, 'rb').read()

--- a/orangecontrib/imageanalytics/local_embedders/squeez_net.py
+++ b/orangecontrib/imageanalytics/local_embedders/squeez_net.py
@@ -1,0 +1,20 @@
+from ndf.example_models import squeezenet
+
+from orangecontrib.imageanalytics.local_embedders.local_embedder import LocalEmbedder
+
+
+class SqueezeNetEmbedder(LocalEmbedder):
+
+    embedder = None
+
+    def _load_model(self):
+        model = squeezenet(include_softmax=False)
+        self.embedder = lambda image: model.predict([image])[0][0]
+
+    def _load_image(self, image_path):
+        image = self._image_loader.load_image_or_none(
+            image_path, self._target_image_size
+        )
+        if image is None:
+            return None
+        return self._image_loader.preprocess_squeezenet(image)

--- a/orangecontrib/imageanalytics/tests/test_image_embedder.py
+++ b/orangecontrib/imageanalytics/tests/test_image_embedder.py
@@ -44,6 +44,8 @@ class ImageEmbedderTest(unittest.TestCase):
         self.embedder_server.clear_cache()
         self.embedder_local = ImageEmbedder(model="squeezenet",)
         self.embedder_local.clear_cache()
+        self.embedder_local_2 = ImageEmbedder(model="tf-inception-v3",)
+        self.embedder_local_2.clear_cache()
         self.single_example = [_EXAMPLE_IMAGE_JPG]
 
         str_var = StringVariable("Image")
@@ -119,6 +121,12 @@ class ImageEmbedderTest(unittest.TestCase):
             self.assertEqual(1, len(emb_))
             self.assertEqual(1000, len(emb_[0]))
 
+        # local embedder 2
+        with self.embedder_local_2 as embedder:
+            emb_ = embedder(self.single_example)
+            self.assertEqual(1, len(emb_))
+            self.assertEqual(2048, len(emb_[0]))
+
     @patch(HTTPX_POST_METHOD, regular_dummy_sr)
     def test_too_many_examples_for_one_batch(self):
         too_many_examples = [_EXAMPLE_IMAGE_JPG for _ in range(200)]
@@ -142,6 +150,11 @@ class ImageEmbedderTest(unittest.TestCase):
         res = np.array(self.embedder_local(more_examples))
         self.assertEqual(res.shape, (5, 1000))
 
+        # local embedder 2
+        more_examples = [_EXAMPLE_IMAGE_JPG for _ in range(5)]
+        res = np.array(self.embedder_local_2(more_examples))
+        self.assertEqual(res.shape, (5, 2048))
+
     def test_invalid_model(self):
         with self.assertRaises(ValueError):
             self.embedder_server = ImageEmbedder(model="invalid_model")
@@ -158,6 +171,10 @@ class ImageEmbedderTest(unittest.TestCase):
         # test local embedder
         res = self.embedder_local([_EXAMPLE_IMAGE_GRAYSCALE])
         self.assertTupleEqual((1, 1000), np.array(res).shape)
+
+        # test local embedder 2
+        res = self.embedder_local_2([_EXAMPLE_IMAGE_GRAYSCALE])
+        self.assertTupleEqual((1, 2048), np.array(res).shape)
 
     @patch(HTTPX_POST_METHOD, regular_dummy_sr)
     def test_with_tiff_image(self):

--- a/orangecontrib/imageanalytics/widgets/tests/__init__.py
+++ b/orangecontrib/imageanalytics/widgets/tests/__init__.py
@@ -1,0 +1,14 @@
+def patch_import():
+    try:
+        import builtins
+    except ImportError:
+        # In Python 2 builtins are __builtin__
+        import __builtin__ as builtins
+    realimport = builtins.__import__
+
+    def import_mock(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tensorflow":
+            raise ImportError
+        return realimport(name, globals, locals, fromlist, level)
+
+    builtins.__import__ = import_mock

--- a/orangecontrib/imageanalytics/widgets/tests/test_owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/tests/test_owimageembedding.py
@@ -5,6 +5,9 @@ from unittest.mock import patch
 import numpy as np
 import pkg_resources
 
+from orangecontrib.imageanalytics.widgets.tests import patch_import
+
+patch_import()
 from Orange.data import Table
 from Orange.misc.utils.embedder_utils import EmbeddingConnectionError
 from Orange.widgets.tests.base import WidgetTest

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ cachecontrol
 lockfile
 ndf>=0.1.4
 scipy
-tensorflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ cachecontrol
 lockfile
 ndf>=0.1.4
 scipy
+tensorflow


### PR DESCRIPTION
##### Issue
Implements local Inception v3 embedded

This contribution add a new local embedded for Inception v3 using TensorFlow. We use the same model used in Server embedded. The model we are using is available [here](http://download.tensorflow.org/models/image/imagenet/inception-2015-12-05.tgz).

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation