### PR TITLE
[FIX] Image embedding: resize an image before sending to the server

### DIFF
--- a/orangecontrib/imageanalytics/image_embedder.py
+++ b/orangecontrib/imageanalytics/image_embedder.py
@@ -139,6 +139,7 @@ class ImageEmbedder:
                 self._model_settings["batch_size"],
                 self.server_url,
                 "image",
+                self._model_settings["target_image_size"]
             )
 
     def __call__(

--- a/orangecontrib/imageanalytics/server_embedder.py
+++ b/orangecontrib/imageanalytics/server_embedder.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 from Orange.misc.server_embedder import ServerEmbedderCommunicator
 from orangecontrib.imageanalytics.utils.embedder_utils import ImageLoader
@@ -11,12 +11,14 @@ class ServerEmbedder(ServerEmbedderCommunicator):
         max_parallel_requests: int,
         server_url: str,
         embbedder_type: str,
+        image_size: Tuple[int, int],
     ) -> None:
         super().__init__(
             model_name, max_parallel_requests, server_url, embbedder_type
         )
         self.content_type = "image/jpeg"
+        self.image_size = image_size
         self._image_loader = ImageLoader()
 
     async def _encode_data_instance(self, file_path: str) -> Optional[bytes]:
-        return self._image_loader.load_image_bytes(file_path)
+        return self._image_loader.load_image_bytes(file_path, self.image_size)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When changing the embedders we forgot to set up the image resizing before sending to the server, this is the reason that some images failed with embedding because they had size more than 1MB.

##### Description of changes
Enable image resizing for each embedder

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation