### PR TITLE
Change documentation theme to Orange's

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -106,7 +106,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'nature'
+html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Some add-ons including imageanalytics use different themes for the documentation. With this PR I set the same theme for add-ons documentation that Orange uses.