### PR TITLE
Change documentation theme to sphinx_rtd_theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,6 +36,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
+    'recommonmark',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -106,7 +106,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'nature'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -135,7 +135,9 @@ html_theme = 'nature'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['static']
+
+html_css_files = ['custom.css']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/static/custom.css
+++ b/doc/static/custom.css
@@ -1,0 +1,13 @@
+/* This CSS snippet makes that the navbar collapse on medium screen already */
+@media screen and (max-width: 950px){
+    .wy-nav-top{display:block}
+    .wy-nav-side{left:-300px}
+    .wy-nav-side.shift{width:85%;left:0}
+    .wy-side-scroll{width:auto}
+    .wy-side-nav-search{width:auto}
+    .wy-menu.wy-menu-vertical{width:auto}
+    .wy-nav-content-wrap{margin-left:0}
+    .wy-nav-content-wrap
+    .wy-nav-content{padding:1.618em}
+    .wy-nav-content-wrap.shift{position:fixed;min-width:100%;left:85%;top:0;height:100%;overflow:hidden}
+}

--- a/orangecontrib/imageanalytics/widgets/__init__.py
+++ b/orangecontrib/imageanalytics/widgets/__init__.py
@@ -16,9 +16,9 @@ BACKGROUND = "#F7F5A8"
 WIDGET_HELP_PATH = (
 # Used for development.
 # You still need to build help pages using
-# make htmlhelp
+# make html
 # inside doc folder
-("{DEVELOP_ROOT}/doc/_build/htmlhelp/index.html", None),
+("{DEVELOP_ROOT}/doc/_build/html/index.html", None),
 
 # Documentation included in wheel
 # Correct DATA_FILES entry is needed in setup.py and documentation has to be

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ def include_documentation(local_dir, install_dir):
 
 
 if __name__ == '__main__':
-    include_documentation('doc/_build/htmlhelp', 'help/orange3-imageanalytics')
+    include_documentation('doc/_build/html', 'help/orange3-imageanalytics')
     setup(
         name=NAME,
         version=VERSION,

--- a/setup.py
+++ b/setup.py
@@ -99,9 +99,8 @@ if __name__ == '__main__':
         classifiers=CLASSIFIERS,
         install_requires=INSTALL_REQUIRES,
         extras_require={
-            'test': [
-                'coverage',
-            ],
+            'test': ['coverage', ],
+            'doc': ['sphinx', 'recommonmark', 'sphinx_rtd_theme', ],
         },
         namespace_packages=['orangecontrib'],
         entry_points=ENTRY_POINTS,


### PR DESCRIPTION
While ago we discussed that we will use the same documentation theme for add-ons. After some discussion, we decided on sphinx-rtd-theme. The alternative is Alabaster but its sidebar is not so readable and it breaks long addon names in two lines.

With this PR I am implementing the sphinx-rtd-theme. I also changed that the menu bar collapses on the medium screen already (before it collapsed on small screens). On the medium screen, the content column was narrow already and it works well for widget documentation in Orange since at the default Orange help window size the sidebar is collapsed.