### PR TITLE
Remove input/output summaries from Image Viewer

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimageviewer.py
+++ b/orangecontrib/imageanalytics/widgets/owimageviewer.py
@@ -997,7 +997,6 @@ class OWImageViewer(widget.OWWidget):
     def setData(self, data):
         self.closeContext()
         self.clear()
-        self.info.set_output_summary(self.info.NoOutput)
         self.data = data
 
         if data is not None:
@@ -1026,9 +1025,7 @@ class OWImageViewer(widget.OWWidget):
 
             if self.stringAttrs:
                 self.setupScene()
-        else:
-            self.info.set_input_summary(self.info.NoInput)
-            self.info.set_output_summary(self.info.NoOutput)
+
         self.commit()
 
     def clear(self):
@@ -1109,9 +1106,7 @@ class OWImageViewer(widget.OWWidget):
     def onSelectionChanged(self):
         selected = [item for item in self.items if item.widget.isSelected()]
         self.selectedIndices = [item.index for item in selected]
-        self.info.set_output_summary(
-            str(len(self.selectedIndices)),
-            f"{len(self.selectedIndices)} images selected")
+
         self.commit()
 
     def commit(self):
@@ -1146,7 +1141,6 @@ class OWImageViewer(widget.OWWidget):
 
         if self._errcount:
             text += f"{self._errcount} errors."
-        self.info.set_input_summary(str(count), text)
         attr = self.stringAttrs[self.imageAttr]
         if self._errcount == count and "type" not in attr.attributes:
             self.error("No images could be ! Make sure the '%s' attribute "

--- a/orangecontrib/imageanalytics/widgets/tests/test_owimageviewer.py
+++ b/orangecontrib/imageanalytics/widgets/tests/test_owimageviewer.py
@@ -49,27 +49,3 @@ class TestOWImageViewer(WidgetTest):
         self.send_signal("Data", None)
         self.assertIsNone(self.get_output(self.widget.Outputs.data))
         self.assertIsNone(self.get_output(self.widget.Outputs.selected_data))
-
-    def test_info_input(self):
-        input_sum = self.widget.info.set_input_summary = Mock()
-
-        self.send_signal(self.widget.Inputs.data, self.image_data)
-        input_sum.assert_called_with(
-            str(len(self.image_data)), '0 of 3 images displayed.\n')
-
-        self.send_signal(self.widget.Inputs.data, None)
-        input_sum.assert_called_with(self.widget.info.NoInput)
-
-    def test_info_output(self):
-        output_sum = self.widget.info.set_output_summary = Mock()
-
-        self.send_signal(self.widget.Inputs.data, self.image_data)
-        output_sum.assert_called_with(self.widget.info.NoOutput)
-
-        self.send_signal(self.widget.Inputs.data, None)
-        output_sum.assert_called_with(self.widget.info.NoOutput)
-
-        self.send_signal(self.widget.Inputs.data, self.image_data)
-        for itm in self.widget.items[:3]:
-            itm.widget.setSelected(True)
-        output_sum.assert_called_with("3", "3 images selected")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Tests started to fail since input/output summaries are now implemented by Orange

##### Description of changes
Remove input/output summaries for Image Viewer

##### Includes
- [x] Code changes
- [x] Tests
- [ ] Documentation