### PR TITLE
[FIX] Identify attributes without image type as image attributes

### DIFF
--- a/orangecontrib/imageanalytics/utils/image_utils.py
+++ b/orangecontrib/imageanalytics/utils/image_utils.py
@@ -1,0 +1,94 @@
+import os
+from typing import List, Union, Optional
+from urllib.parse import urlparse, urljoin
+
+from Orange.data import (
+    Table,
+    Variable,
+    StringVariable,
+    DiscreteVariable,
+    Instance,
+    Unknown,
+)
+
+
+def filter_image_attributes(data: Table) -> List[Variable]:
+    """
+    Filter out attributes which can potentially be an image attributes. The
+    selection includes all String and Categorical attributes from meta part of
+    the table. Put attributes with "type" == "image" first - they are more likely
+    to be image attributes.
+
+    Parameters
+    ----------
+    data
+        Table with data
+
+    Returns
+    -------
+    List of variables that can be image attributes
+    """
+    m = data.domain.metas
+    m = [a for a in m if isinstance(a, (StringVariable, DiscreteVariable))]
+    return sorted(m, key=lambda a: a.attributes.get("type") == "image", reverse=True)
+
+
+def extract_paths(
+    data: Table, column: Union[DiscreteVariable, StringVariable]
+) -> List[Optional[str]]:
+    """
+    Extract image/file paths from datatable column. If column has an origin attribute
+    it will be added as a prefix to the path otherwise just values of column will be
+    returned.
+
+    Parameters
+    ----------
+    data
+        Table that have column with file paths/URL in metas
+    column
+        Variable which is a path attribute. Must be string or categorical
+
+    Returns
+    -------
+    List of file paths or URLs
+    """
+    return [extract_image_path(inst, column) for inst in data]
+
+
+def extract_image_path(
+    instance: Instance, attribute: Union[DiscreteVariable, StringVariable]
+) -> Optional[str]:
+    """
+    Extract image/file path from instance's attribute. If attribute has an origin
+    attribute it will be added as a prefix to the path otherwise just values of column
+    will be returned.
+
+    Parameters
+    ----------
+    instance
+        Instance that have column with file paths/URL in metas
+    attribute
+        Variable which is a path attribute. Must be string or categorical
+
+    Returns
+    -------
+    File paths or URL
+    """
+    file_path = instance[attribute].value
+    if file_path == "" or file_path is Unknown:
+        return None
+
+    origin = attribute.attributes.get("origin", "")
+    if (
+        urlparse(origin).scheme in ("http", "https", "ftp", "data")
+        and origin[-1] != "/"
+    ):
+        origin += "/"
+
+    urlparts = urlparse(file_path)
+    if urlparts.scheme not in ("http", "https", "ftp", "data"):
+        if urlparse(origin).scheme in ("http", "https", "ftp", "data"):
+            file_path = urljoin(origin, file_path)
+        else:
+            file_path = os.path.join(origin, file_path)
+    return file_path

--- a/orangecontrib/imageanalytics/utils/tests/test_image_utils.py
+++ b/orangecontrib/imageanalytics/utils/tests/test_image_utils.py
@@ -1,0 +1,124 @@
+import os
+import unittest
+from unittest import TestCase
+
+import numpy as np
+from Orange.data import (
+    Domain,
+    DiscreteVariable,
+    ContinuousVariable,
+    Table,
+    StringVariable,
+)
+
+from orangecontrib.imageanalytics.utils.image_utils import (
+    filter_image_attributes,
+    extract_paths,
+)
+from orangecontrib.imageanalytics.widgets.tests.utils import load_images
+
+
+class TestImageUtils(TestCase):
+    def test_filter_image_attributes(self):
+        table = load_images()
+
+        self.assertEqual([table.domain.metas[0]], filter_image_attributes(table))
+
+        # add some more attributes
+        a, b, c = DiscreteVariable("a"), ContinuousVariable("b"), table.domain.metas[0]
+        domain = Domain([], metas=[a, b, c])
+        table_new = table.transform(domain)
+        # c - attribute with image type should be first
+        self.assertEqual([c, a], filter_image_attributes(table_new))
+
+        domain = Domain([], metas=[])
+        table_new = table.transform(domain)
+        self.assertEqual([], filter_image_attributes(table_new))
+
+    def test_extract_paths(self):
+        origin = os.path.abspath(
+            os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                "..", "..",
+                "widgets",
+                "tests",
+                "test_images",
+            )
+        )
+        images = [
+            "afternoon-4175917_640.jpg",
+            "atomium-4179270_640.jpg",
+            "kittens-4020199_640.jpg",
+            "landscape-2130524_640.jpg",
+        ]
+        expected_paths = [os.path.join(origin, image) for image in images]
+
+        # test with string variable
+        table = load_images()
+        paths = extract_paths(table, column=table.domain.metas[0])
+        self.assertListEqual(expected_paths, paths)
+
+        # test with string variable including unknown values
+        with table.unlocked():
+            table.metas[0, 0] = ""
+        paths = extract_paths(table, column=table.domain.metas[0])
+        self.assertListEqual([None] + expected_paths[1:], paths)
+
+        # test with categorical variable
+        var = DiscreteVariable("images", values=images)
+        var.attributes.update(table.domain.metas[0].attributes)
+        new_domain = Domain([], metas=[var])
+        new_table = Table.from_numpy(
+            new_domain, np.empty((4, 0)), metas=np.array([[0], [1], [2], [3]])
+        )
+        paths = extract_paths(new_table, column=new_domain.metas[0])
+        self.assertEqual(expected_paths, paths)
+
+        # test with categorical variable including unknown values
+        with table.unlocked():
+            table.metas[0, 0] = ""
+        paths = extract_paths(table, column=table.domain.metas[0])
+        self.assertListEqual([None] + expected_paths[1:], paths)
+
+        # test string no origin
+        var = StringVariable("images")
+        new_domain = Domain([], metas=[var])
+        new_table = Table.from_numpy(
+            new_domain, np.empty((4, 0)), metas=np.array([[f"/{x}"] for x in images])
+        )
+        paths = extract_paths(new_table, column=new_domain.metas[0])
+        self.assertEqual([f"/{x}" for x in images], paths)
+
+        # test categorical no origin
+        var = DiscreteVariable("images", values=[f"/{x}" for x in images])
+        new_domain = Domain([], metas=[var])
+        new_table = Table.from_numpy(
+            new_domain, np.empty((4, 0)), metas=np.array([[0], [1], [2], [3]])
+        )
+        paths = extract_paths(new_table, column=new_domain.metas[0])
+        self.assertEqual([f"/{x}" for x in images], paths)
+
+        # test urls with origin
+        var = StringVariable("images")
+        var.attributes = {"origin": "https://example.com", "type": "image"}
+        new_domain = Domain([], metas=[var])
+        new_table = Table.from_numpy(
+            new_domain, np.empty((4, 0)), metas=np.array([[x] for x in images])
+        )
+        paths = extract_paths(new_table, column=new_domain.metas[0])
+        self.assertEqual([f"https://example.com/{x}" for x in images], paths)
+
+        # test urls no origin
+        var = StringVariable("images")
+        new_domain = Domain([], metas=[var])
+        new_table = Table.from_numpy(
+            new_domain,
+            np.empty((4, 0)),
+            metas=np.array([[f"https://example.com/{x}"] for x in images]),
+        )
+        paths = extract_paths(new_table, column=new_domain.metas[0])
+        self.assertEqual([f"https://example.com/{x}" for x in images], paths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/imageanalytics/widgets/tests/utils.py
+++ b/orangecontrib/imageanalytics/widgets/tests/utils.py
@@ -7,7 +7,7 @@ from Orange.data import StringVariable, Table, Domain
 def load_images():
     path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                         "test_images")
-    files = [[x] for x in os.listdir(path)]
+    files = [[x] for x in sorted(os.listdir(path))]
 
     image_var = StringVariable(name="Images")
     image_var.attributes["type"] = "image"


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
- Fixes https://github.com/biolab/orange3-imageanalytics/issues/191
- Attributes are differently selected in different widgets
- Paths are differently treated accros widgets (and code is duplicated).

##### Description of changes
- Common module for image attribute identification and paths concatenation
- Use those common functions in the widget

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation