### PR TITLE
Image Grid - replace deprecated colorpalette with colorpalettes module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2016]
+        os: [ubuntu-18.04, macos-10.15, windows-2019]
         python-version: [3.7, 3.8]
         tox_env: [py-orange-released]
         experimental: [false]
         name: [Released]
         include:
-          - os: windows-2019
+          - os: windows-latest
             python-version: 3.8
             tox_env: py-orange-released
             experimental: true
@@ -34,7 +34,7 @@ jobs:
             experimental: true
             name: Big Sur
 
-          - os: windows-2016
+          - os: windows-2019
             python-version: 3.7
             tox_env: py-orange-oldest
             experimental: false
@@ -50,7 +50,7 @@ jobs:
             name: Oldest
             experimental: false
 
-          - os: windows-2016
+          - os: windows-2019
             python-version: 3.8
             tox_env: py-orange-latest
             experimental: false

--- a/orangecontrib/imageanalytics/tests/test_image_embedder.py
+++ b/orangecontrib/imageanalytics/tests/test_image_embedder.py
@@ -27,7 +27,7 @@ class DummyResponse:
 
 def make_dummy_post(response, sleep=0):
     @staticmethod
-    async def dummy_post(url, headers, data):
+    async def dummy_post(url, headers, data=None, content=None):
         await asyncio.sleep(sleep)
         return DummyResponse(content=response)
 

--- a/orangecontrib/imageanalytics/widgets/owimagegrid.py
+++ b/orangecontrib/imageanalytics/widgets/owimagegrid.py
@@ -31,7 +31,7 @@ from Orange.widgets import widget, gui, settings
 from Orange.widgets.settings import ContextSetting
 from Orange.widgets.utils.annotated_data import (
     create_annotated_table, create_groups_table)
-from Orange.widgets.utils.colorpalette import ColorPaletteGenerator
+from Orange.widgets.utils.colorpalettes import LimitedDiscretePalette
 from Orange.widgets.utils.itemmodels import VariableListModel, DomainModel
 from Orange.widgets.utils.overlay import proxydoc
 from Orange.widgets.widget import Input, Output, OWWidget, Msg
@@ -483,7 +483,7 @@ class OWImageGrid(widget.OWWidget):
         if sels == 1:
             brushes = [no_brush, no_brush]
         else:
-            palette = ColorPaletteGenerator(number_of_colors=sels + 1)
+            palette = LimitedDiscretePalette(number_of_colors=sels + 1)
             brushes = [no_brush] + [QBrush(palette[i]) for i in range(sels)]
         brush = [brushes[a] for a in self.selection]
 
@@ -922,8 +922,7 @@ class GraphicsThumbnailGrid(QGraphicsWidget):
     def __scheduleLayout(self):
         if not self.__reflowPending:
             self.__reflowPending = True
-            QApplication.postEvent(
-                self, QEvent(QEvent.LayoutRequest), Qt.HighEventPriority)
+            QApplication.postEvent(self, QEvent(QEvent.LayoutRequest))
 
     def event(self, event):
         if event.type() == QEvent.LayoutRequest:
@@ -1286,7 +1285,7 @@ class GraphicsScene(QGraphicsScene):
 
     # override the default signal since it should only be emitted when a
     # selection is finished
-    selectionChanged = Signal(set, int)
+    selectionChanged = Signal(set, Qt.KeyboardModifier)
 
     def __init__(self, *args):
         QGraphicsScene.__init__(self, *args)

--- a/orangecontrib/imageanalytics/widgets/owimageviewer.py
+++ b/orangecontrib/imageanalytics/widgets/owimageviewer.py
@@ -701,7 +701,7 @@ class ImageLoader(QObject):
             QNetworkRequest.PreferCache
         )
         request.setAttribute(
-            QNetworkRequest.FollowRedirectsAttribute, True
+            QNetworkRequest.RedirectPolicyAttribute, True
         )
         request.setMaximumRedirectsAllowed(5)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The image grid still uses colorpalette module https://github.com/biolab/orange3/pull/6135

##### Description of changes
Replace it with colorpalettes.
Fix pyqt6 compatibility issues

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation