### PR TITLE
Image Embedding - show more descriptive error

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/owimageembedding.py
@@ -2,7 +2,6 @@ import logging
 from types import SimpleNamespace
 from typing import Optional
 
-import numpy as np
 from AnyQt.QtCore import Qt
 from AnyQt.QtWidgets import QLayout, QPushButton, QStyle
 
@@ -285,9 +284,8 @@ class OWImageEmbedding(OWWidget, ConcurrentWidgetMixin):
         log = logging.getLogger(__name__)
         log.debug(ex, exc_info=ex)
         self.cancel_button.setDisabled(True)
-        self.Error.unexpected_error(type(ex).__name__)
+        self.Error.unexpected_error(str(ex))
         self.clear_outputs()
-        logging.debug("Exception", exc_info=ex)
 
     def cancel(self):
         self.cancel_button.setDisabled(True)

--- a/orangecontrib/imageanalytics/widgets/tests/test_owimageembedding.py
+++ b/orangecontrib/imageanalytics/widgets/tests/test_owimageembedding.py
@@ -158,7 +158,7 @@ class TestOWImageEmbedding(WidgetTest):
     @mock.patch(
         "orangecontrib.imageanalytics.server_embedder.ServerEmbedder."
         "embedd_data",
-        side_effect=OSError,
+        side_effect=OSError("Connection failed"),
     )
     def test_unexpected_error(self, _):
         """
@@ -175,6 +175,10 @@ class TestOWImageEmbedding(WidgetTest):
         output = self.get_output(self.widget.Outputs.embeddings)
         self.assertIsNone(output)
         self.widget.Error.unexpected_error.is_shown()
+        self.assertEqual(
+            "Embedding error: Connection failed",
+            str(self.widget.Error.unexpected_error),
+        )
 
     @patch(HTTPX_POST_METHOD, regular_dummy_sr)
     def test_rerun_on_new_data(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description if the issue does not exist. -->
The error that the Image Embedding widget shows do not describe what happened. It just shows the type of error (for example OSError).

##### Description of changes
Show the error text instead of the error type

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation