### PR TITLE
Temporarily fix urllib3 version

### DIFF
--- a/orangecontrib/imageanalytics/tests/test_dependencies.py
+++ b/orangecontrib/imageanalytics/tests/test_dependencies.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from unittest import TestCase
+
+
+class TestUrllib(TestCase):
+    def test_remove_urllib_fix(self):
+        """
+        When test start to fail check https://github.com/ionrock/cachecontrol/pull/294
+        if already fixed and if fix cachecontrol also released. If true:
+        - remove this test file
+        - remove urllib3 pin (line 104 and 105)
+        """
+        self.assertLess(datetime.today(), datetime(2023, 5,30))

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,8 @@ if __name__ == '__main__':
             "orange-widget-base >=4.20.0",
             "pillow >=6.2.0",
             "requests",
+            # temporary fixes https://github.com/ionrock/cachecontrol/pull/294
+            "urllib3<2",
             "scipy",
         ],
         extras_require={


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Save Images tests started to fail because of https://github.com/ionrock/cachecontrol/pull/294

##### Description of changes
Temporarily fix the urllib3 version and introduce time-bomb to remind to remove the fix.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation