### PR TITLE
[ENH] Replace cachecontrol with requests_cache

### DIFF
--- a/orangecontrib/imageanalytics/local_embedder.py
+++ b/orangecontrib/imageanalytics/local_embedder.py
@@ -1,9 +1,3 @@
-from os.path import join
-
-import cachecontrol.caches
-import requests
-
-from Orange.canvas.config import cache_dir
 from Orange.misc.utils.embedder_utils import EmbedderCache
 from Orange.util import dummy_callback
 from orangecontrib.imageanalytics.utils.embedder_utils import ImageLoader
@@ -17,13 +11,6 @@ class LocalEmbedder:
         self.embedder = model_settings["model"]()
 
         self._target_image_size = model_settings["target_image_size"]
-
-        self._session = cachecontrol.CacheControl(
-            requests.session(),
-            cache=cachecontrol.caches.FileCache(
-                join(cache_dir(), __name__ + ".ImageEmbedder.httpcache")
-            ),
-        )
 
         self._image_loader = ImageLoader()
         self._cache = EmbedderCache(model)

--- a/orangecontrib/imageanalytics/utils/tests/test_embedder_utils.py
+++ b/orangecontrib/imageanalytics/utils/tests/test_embedder_utils.py
@@ -3,7 +3,9 @@ import unittest
 from unittest.mock import patch
 from urllib.error import URLError
 
+import numpy as np
 from PIL.Image import Image
+from numpy.testing import assert_array_equal
 from requests import RequestException
 
 from orangecontrib.imageanalytics.utils.embedder_utils import ImageLoader
@@ -49,6 +51,10 @@ class TestImageLoader(unittest.TestCase):
         """
         image = self.image_loader.load_image_or_none(self.im_url)
         self.assertTrue(isinstance(image, Image))
+        image_array = np.array(image)
+        # manually checked values
+        assert_array_equal(image_array[147, 181], [103, 10, 0])
+        assert_array_equal(image_array[305, 331], [21, 1, 2])
 
         image = self.image_loader.load_image_or_none(self.im_paths[0],
                                                      target_size=(255, 255))
@@ -59,7 +65,7 @@ class TestImageLoader(unittest.TestCase):
         image = self.image_loader.load_image_or_none(self.im_url + "a")
         self.assertIsNone(image)
 
-    @patch("requests.sessions.Session.get", side_effect=RequestException)
+    @patch("requests_cache.CachedSession.get", side_effect=RequestException)
     def test_load_images_url_request_exception(self, _) -> None:
         """
         Handle loading images from http, https type urls

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,6 @@ if __name__ == '__main__':
         classifiers=CLASSIFIERS,
         install_requires=[
             "AnyQt",
-            "cachecontrol[filecache]",
             "ndf >=0.1.4",
             "numpy >=1.16",
             "Orange3 >=3.34.0",
@@ -104,6 +103,7 @@ if __name__ == '__main__':
             # constraint when requiring Orange> 3.35
             "pandas <2.1",
             "requests",
+            "requests_cache",
             "scipy",
         ],
         extras_require={


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3-imageanalytics/issues/235
Cachecontrol was replaced with `requests_cache` in `orangewidgetbase`, and now when the image analytics addon gets installed, both cachecontrol and `requests_cache` are installed (cachecontrol is still required in image analytics). And they do the same job. `requests_cache` is also better maintained.

##### Description of changes
Replace cachecontrol with requests_cache to have only one of the packages installed.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation