### PR TITLE
Save build requirements into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "trubar>=0.3.3"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,6 @@ if __name__ == '__main__':
         package_data=PACKAGE_DATA,
         keywords=KEYWORDS,
         classifiers=CLASSIFIERS,
-        setup_requires=["trubar>=0.3.3"],
         install_requires=[
             "AnyQt",
             "ndf >=0.1.4",


### PR DESCRIPTION
##### Issue
There was a PEP-517 warning before:
```
python setup.py bdist_wheel
/home/marko/venv310/lib/python3.10/site-packages/setuptools/__init__.py:94: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
!!

        ********************************************************************************
        Requirements should be satisfied by a PEP 517 installer.
        If you are using pip, you can try `pip install --use-pep517`.
        ********************************************************************************

```

This makes it disappear.
