### PR TITLE
[FIX] owimageimport: Disable dynamic output

### DIFF
--- a/orangecontrib/imageanalytics/widgets/owimageimport.py
+++ b/orangecontrib/imageanalytics/widgets/owimageimport.py
@@ -103,7 +103,7 @@ class OWImportImages(widget.OWWidget):
     priority = 110
 
     class Outputs:
-        data = Output('Data', Table, default=True)
+        data = Output('Data', Table, default=True, dynamic=False)
 
     #: list of recent paths
     recent_paths = settings.Setting([])  # type: List[RecentPath]

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
     oldest: orange3==3.37.0
     oldest: orange-canvas-core==0.2.2
     oldest: orange-widget-base==4.23.0
+    oldest: httpx==0.21.0
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Dynamic output is not applicable here.

##### Description of changes

Disable dynamic output

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation